### PR TITLE
Remove storage permission on API >= 19

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -24,7 +24,7 @@
     package="au.id.micolous.farebot">
 
     <uses-permission android:name="android.permission.NFC" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="18"/>
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 

--- a/src/main/java/au/id/micolous/metrodroid/activity/AddKeyActivity.java
+++ b/src/main/java/au/id/micolous/metrodroid/activity/AddKeyActivity.java
@@ -66,7 +66,6 @@ import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
  * @author Eric Butler
  */
 public class AddKeyActivity extends Activity {
-    private static final int STORAGE_PERMISSION_CALLBACK = 1000;
     private NfcAdapter mNfcAdapter;
     private PendingIntent mPendingIntent;
     private String[][] mTechLists = new String[][]{
@@ -127,33 +126,9 @@ public class AddKeyActivity extends Activity {
         mPendingIntent = PendingIntent.getActivity(this, 0, intent, 0);
 
         if (getIntent().getAction() != null && getIntent().getAction().equals(Intent.ACTION_VIEW) && getIntent().getData() != null) {
-            // Request permission for storage first
-            if (ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
-                ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, STORAGE_PERMISSION_CALLBACK);
-            } else {
-                // Just read the key file
-                readKeyFile();
-            }
-
-
+            readKeyFile();
         } else {
             finish();
-        }
-    }
-
-    @Override
-    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
-        switch (requestCode) {
-            case STORAGE_PERMISSION_CALLBACK:
-                if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    // Permission granted.
-                    readKeyFile();
-                } else {
-                    // Permission denied.
-                    Utils.showErrorAndFinish(this, R.string.storage_required);
-                }
-
-                break;
         }
     }
 

--- a/src/main/java/au/id/micolous/metrodroid/activity/CardsActivity.java
+++ b/src/main/java/au/id/micolous/metrodroid/activity/CardsActivity.java
@@ -22,46 +22,14 @@
 
 package au.id.micolous.metrodroid.activity;
 
-import android.Manifest;
 import android.app.Fragment;
-import android.content.pm.PackageManager;
-import android.os.Bundle;
-import android.support.v4.app.ActivityCompat;
-import android.support.v4.content.ContextCompat;
-import android.widget.Toast;
 
 import au.id.micolous.metrodroid.fragment.CardsFragment;
 
-import au.id.micolous.farebot.R;
 
 public class CardsActivity extends FragmentWrapperActivity {
-    private static final int STORAGE_PERMISSION_CALLBACK = 1001;
-
     @Override
     protected Fragment createFragment() {
         return new CardsFragment();
-    }
-
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
-        // Request permission for storage right away, as requesting this when a file is explicitly
-        // opened is tedious.
-        if (ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
-            ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, STORAGE_PERMISSION_CALLBACK);
-        }
-    }
-
-    @Override
-    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
-        switch (requestCode) {
-            case STORAGE_PERMISSION_CALLBACK:
-                if (grantResults.length == 0 || grantResults[0] != PackageManager.PERMISSION_GRANTED) {
-                    // Permission denied.
-                    Toast.makeText(this, R.string.storage_required, Toast.LENGTH_LONG).show();
-                }
-                break;
-        }
     }
 }

--- a/src/main/java/au/id/micolous/metrodroid/activity/KeysActivity.java
+++ b/src/main/java/au/id/micolous/metrodroid/activity/KeysActivity.java
@@ -22,46 +22,14 @@
 
 package au.id.micolous.metrodroid.activity;
 
-import android.Manifest;
 import android.app.Fragment;
-import android.content.pm.PackageManager;
-import android.os.Bundle;
-import android.support.v4.app.ActivityCompat;
-import android.support.v4.content.ContextCompat;
-import android.widget.Toast;
 
 import au.id.micolous.metrodroid.fragment.KeysFragment;
 
-import au.id.micolous.farebot.R;
-
 public class KeysActivity extends FragmentWrapperActivity {
-    private static final int STORAGE_PERMISSION_CALLBACK = 1001;
 
     @Override
     protected Fragment createFragment() {
         return new KeysFragment();
-    }
-
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
-        // Request permission for storage right away, as requesting this when a file is explicitly
-        // opened is tedious.
-        if (ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
-            ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, STORAGE_PERMISSION_CALLBACK);
-        }
-    }
-
-    @Override
-    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
-        switch (requestCode) {
-            case STORAGE_PERMISSION_CALLBACK:
-                if (grantResults.length == 0 || grantResults[0] != PackageManager.PERMISSION_GRANTED) {
-                    // Permission denied.
-                    Toast.makeText(this, R.string.storage_required, Toast.LENGTH_LONG).show();
-                }
-                break;
-        }
     }
 }


### PR DESCRIPTION
Metrodroid reads only files from its own directory and through
StorageAccessFramework. Neither of them needs permission be it in
manifest or runtime.