### PR TITLE
Fix import and export functionality.

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -40,6 +40,15 @@
         android:label="@string/app_name"
         android:name="au.id.micolous.metrodroid.MetrodroidApplication"
         android:theme="@android:style/Theme.DeviceDefault">
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths"/>
+        </provider>
         <activity
             android:name="au.id.micolous.metrodroid.activity.MainActivity"
             android:configChanges="keyboardHidden|orientation"

--- a/src/main/res/xml/provider_paths.xml
+++ b/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path name="share" path="share"/>
+</paths>


### PR DESCRIPTION
Export all pushes the file size up by a lot. So old code doesn\t work with this
file size. This fixes several issues:

* Writing/reading files/sharing has to be done in async tasks with at most
a weak reference to fragment (strictmode and everything)
* file is too large to fit in a parcel atached to intent. So it needs to be
saved and then passed as an URI.
* Missing close() call resulted in 0-size files when saving to drive

Paths for pre-KitKat were left alone as it's less of an issue.