### PR TITLE
Support showing trips without starting time or location

### DIFF
--- a/src/main/java/au/id/micolous/metrodroid/fragment/CardTripsFragment.java
+++ b/src/main/java/au/id/micolous/metrodroid/fragment/CardTripsFragment.java
@@ -157,7 +157,11 @@ public class CardTripsFragment extends ListFragment {
 
             Trip trip = getItem(position);
 
-            Calendar date = trip.getStartTimestamp();
+            Calendar start = trip.getStartTimestamp();
+            Calendar date = start;
+
+            if (date == null)
+                date = trip.getEndTimestamp();
 
             View listHeader = convertView.findViewById(R.id.list_header);
             if (isFirstInSection(position)) {
@@ -254,7 +258,13 @@ public class CardTripsFragment extends ListFragment {
             }
 
             if (trip.hasTime()) {
-                timeTextView.setText(Utils.timeFormat(date));
+                Calendar end = trip.getEndTimestamp();
+                if (end != null && start != null)
+                    timeTextView.setText(Utils.localizeString(R.string.time_from_to, Utils.timeFormat(start), Utils.timeFormat(end)));
+                else if (start != null)
+                    timeTextView.setText(Utils.timeFormat(start));
+                else
+                    timeTextView.setText(Utils.localizeString(R.string.time_from_unknown_to, Utils.timeFormat(end)));
                 timeTextView.setVisibility(View.VISIBLE);
             } else {
                 timeTextView.setVisibility(View.INVISIBLE);
@@ -339,7 +349,11 @@ public class CardTripsFragment extends ListFragment {
             if (position == 0) return true;
 
             Calendar date1 = getItem(position).getStartTimestamp();
+            if (date1 == null)
+                date1 = getItem(position).getEndTimestamp();
             Calendar date2 = getItem(position - 1).getStartTimestamp();
+            if (date2 == null)
+                date2 = getItem(position - 1).getEndTimestamp();
 
             if (date1 == null && date2 != null) return true;
             if (date1 == null || date2 == null) return false;

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -517,6 +517,13 @@
       Spoken: "From Tokyo  to Osaka"
     -->
     <string name="trip_description">(From )%1$s [→] (to )%2$s</string>
+    <!-- Translators: it's used when departure point isn't known -->
+    <string name="trip_description_unknown_start">[? →] (to )%s</string>
+    <!-- Translators: it's used to show time in trip listing e.g. 12:35 - 12:51 -->
+    <string name="time_from_to">%s → %s</string>
+    <!-- Translators: it's used when departure time isn't known -->
+    <string name="time_from_unknown_to">\??:?? → %s</string>
+
 
     <!-- Locations -->
     <string name="location_seattle">Seattle, WA, USA</string>


### PR DESCRIPTION
Current solution is to pretend that end time/station is start time/station
if no real start data is available. It's confusing as there is no
distinguishing between start and end visually and hence it can be assumed
it's a start of a journey rather than the end. It's tolerable for occasional
hiccup but Shenzhen Tong has only ending stations AFAICT.