### PR TITLE
Allow showing both local and English name at the same time

### DIFF
--- a/src/main/java/au/id/micolous/metrodroid/MetrodroidApplication.java
+++ b/src/main/java/au/id/micolous/metrodroid/MetrodroidApplication.java
@@ -87,6 +87,7 @@ public class MetrodroidApplication extends Application {
     public static final String PREF_LOCALISE_PLACES = "pref_localise_places";
     public static final String PREF_LOCALISE_PLACES_HELP = "pref_localise_places_help";
     public static final String PREF_CONVERT_TIMEZONES = "pref_convert_timezones";
+    public static final String PREF_SHOW_LOCAL_AND_ENGLISH = "pref_show_local_and_english";
     private static final Set<String> devicesMifareWorks = new HashSet<>();
     private static final Set<String> devicesMifareNotWorks = new HashSet<>();
 
@@ -189,6 +190,10 @@ public class MetrodroidApplication extends Application {
 
     public static boolean convertTimezones() {
         return getBooleanPref(PREF_CONVERT_TIMEZONES, false);
+    }
+
+    public static boolean showBothLocalAndEnglish() {
+        return getBooleanPref(PREF_SHOW_LOCAL_AND_ENGLISH, false);
     }
 
     public Serializer getSerializer() {

--- a/src/main/java/au/id/micolous/metrodroid/util/StationTableReader.java
+++ b/src/main/java/au/id/micolous/metrodroid/util/StationTableReader.java
@@ -29,6 +29,7 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Locale;
 
+import au.id.micolous.metrodroid.MetrodroidApplication;
 import au.id.micolous.metrodroid.proto.Stations;
 import au.id.micolous.metrodroid.transit.Station;
 
@@ -100,6 +101,14 @@ public class StationTableReader {
     }
 
     String selectBestName(String englishName, String localName) {
+        if (showBoth() && englishName != null && !englishName.equals("")
+                && localName != null && !localName.equals("")) {
+            if (englishName.equals(localName))
+                return localName;
+            if (useEnglishName())
+                return englishName + " (" + localName + ")";
+            return localName + " (" + englishName + ")";
+        }
         if (useEnglishName() && englishName != null && !englishName.equals("")) {
             return englishName;
         }
@@ -111,6 +120,10 @@ public class StationTableReader {
             // Local unavailable, use English
             return englishName;
         }
+    }
+
+    private boolean showBoth() {
+        return MetrodroidApplication.showBothLocalAndEnglish();
     }
 
     /**

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -824,4 +824,7 @@
         uniquely identified and linked to a database but card itself contains no other data.
     </string>
     <string name="fully_blank_title">Blank card</string>
+
+    <string name="pref_show_local_and_english_title">Show both local and English station names</string>
+    <string name="pref_show_local_and_english_desc">If true both local and English names will be shown independently of locale. If false the most appropriate variant is chosen</string>
 </resources>

--- a/src/main/res/xml/prefs.xml
+++ b/src/main/res/xml/prefs.xml
@@ -120,5 +120,11 @@
             android:summary="@string/speak_balance_summary"
             android:key="pref_key_speak_balance"
             android:defaultValue="false" />
+
+        <CheckBoxPreference
+            android:title="@string/pref_show_local_and_english_title"
+            android:summary="@string/pref_show_local_and_english_desc"
+            android:key="pref_show_local_and_english"
+            android:defaultValue="false" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
This is useful both for devs to check that both names are determined
correctly and for the end users who may know some of foreign language
and may be willing to compare visually with writings.