### PR TITLE
Move mdst names out of MetrodroidApplication.

### DIFF
--- a/src/androidTest/java/au/id/micolous/metrodroid/test/StationTableReaderTest.java
+++ b/src/androidTest/java/au/id/micolous/metrodroid/test/StationTableReaderTest.java
@@ -15,7 +15,7 @@ import au.id.micolous.metrodroid.util.StationTableReader;
 public class StationTableReaderTest extends AndroidTestCase {
     public void testSeqGoDatabase() throws Exception {
         TestUtils.setLocale(getContext(), "en-US");
-        StationTableReader str = MetrodroidApplication.getInstance().getSeqGoSTR();
+        StationTableReader str = StationTableReader.getSTR(SeqGoTrip.SEQ_GO_STR);
         Station s = str.getStationById(SeqGoTrip.DOMESTIC_AIRPORT);
         assertEquals("Domestic Airport", s.getStationName());
 

--- a/src/main/java/au/id/micolous/metrodroid/MetrodroidApplication.java
+++ b/src/main/java/au/id/micolous/metrodroid/MetrodroidApplication.java
@@ -99,12 +99,6 @@ public class MetrodroidApplication extends Application {
 
     private static MetrodroidApplication sInstance;
 
-    private StationTableReader mLaxTapSTR = null;
-    private StationTableReader mSeqGoSTR = null;
-    private StationTableReader mSuicaRailSTR = null;
-    private StationTableReader mSuicaBusSTR = null;
-    private StationTableReader mOVChipSTR = null;
-
     private final Serializer mSerializer;
     private boolean mHasNfcHardware = false;
     private boolean mMifareClassicSupport = false;
@@ -204,66 +198,6 @@ public class MetrodroidApplication extends Application {
 
     public boolean getMifareClassicSupport() {
         return mMifareClassicSupport;
-    }
-
-    public StationTableReader getSuicaRailSTR() {
-        if (mSuicaRailSTR == null) {
-            try {
-                mSuicaRailSTR = new StationTableReader(this, "suica_rail.mdst");
-            } catch (Exception e) {
-                Log.w(TAG, "Couldn't open suica_rail", e);
-            }
-        }
-
-        return mSuicaRailSTR;
-    }
-
-    public StationTableReader getSuicaBusSTR() {
-        if (mSuicaBusSTR == null) {
-            try {
-                mSuicaBusSTR = new StationTableReader(this, "suica_bus.mdst");
-            } catch (Exception e) {
-                Log.w(TAG, "Couldn't open suica_bus", e);
-            }
-        }
-
-        return mSuicaBusSTR;
-    }
-
-    public StationTableReader getOVChipSTR() {
-        if (mOVChipSTR == null) {
-            try {
-                mOVChipSTR = new StationTableReader(this, "ovc.mdst");
-            } catch (Exception e) {
-                Log.w(TAG, "Couldn't open ovc", e);
-            }
-        }
-
-        return mOVChipSTR;
-    }
-
-    public StationTableReader getSeqGoSTR() {
-        if (mSeqGoSTR == null) {
-            try {
-                mSeqGoSTR = new StationTableReader(this, "seq_go.mdst");
-            } catch (Exception e) {
-                Log.w(TAG, "Couldn't open seq_go", e);
-            }
-        }
-
-        return mSeqGoSTR;
-    }
-
-    public StationTableReader getLaxTapSTR() {
-        if (mLaxTapSTR == null) {
-            try {
-                mLaxTapSTR = new StationTableReader(this, "lax_tap.mdst");
-            } catch (Exception e) {
-                Log.w(TAG, "Couldn't open lax_tap", e);
-            }
-        }
-
-        return mLaxTapSTR;
     }
 
     @Override

--- a/src/main/java/au/id/micolous/metrodroid/transit/lax_tap/LaxTapData.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/lax_tap/LaxTapData.java
@@ -30,6 +30,7 @@ public final class LaxTapData {
     static final int AGENCY_METRO = 1;
     static final int AGENCY_CULVER_CITY = 3;
     static final int AGENCY_SANTA_MONICA = 11;
+    static final String LAX_TAP_STR = "lax_tap";
 
     // Metro has Subway, Light Rail and Bus services, but all on the same Agency ID on the card.
     // Subway services are < LR_START, and Light Rail services are between LR_START and BUS_START.

--- a/src/main/java/au/id/micolous/metrodroid/transit/lax_tap/LaxTapTrip.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/lax_tap/LaxTapTrip.java
@@ -108,7 +108,7 @@ public class LaxTapTrip extends NextfareTrip {
             return null;
         }
 
-        StationTableReader str = MetrodroidApplication.getInstance().getLaxTapSTR();
+        StationTableReader str = StationTableReader.getSTR(LaxTapData.LAX_TAP_STR);
         if (str == null) return null;
 
         try {

--- a/src/main/java/au/id/micolous/metrodroid/transit/ovc/OVChipTrip.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/ovc/OVChipTrip.java
@@ -50,6 +50,7 @@ public class OVChipTrip extends Trip {
             return new OVChipTrip[size];
         }
     };
+    private static final String OVCHIP_STR = "ovc";
     private final int mId;
     private final int mProcessType;
     private final int mAgency;
@@ -184,7 +185,7 @@ public class OVChipTrip extends Trip {
         int stationId = ((companyCode - 1) << 16) + stationCode;
         if (stationId <= 0) return null;
 
-        StationTableReader str = MetrodroidApplication.getInstance().getOVChipSTR();
+        StationTableReader str = StationTableReader.getSTR(OVCHIP_STR);
         if (str == null) return null;
 
         try {

--- a/src/main/java/au/id/micolous/metrodroid/transit/seq_go/SeqGoTrip.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/seq_go/SeqGoTrip.java
@@ -52,6 +52,7 @@ public class SeqGoTrip extends NextfareTrip {
     public static final int DOMESTIC_AIRPORT = 9;
     public static final int INTERNATIONAL_AIRPORT = 10;
     private static final String TAG = SeqGoTrip.class.getSimpleName();
+    public static final String SEQ_GO_STR = "seq_go";
 
     /**
      * This constructor is used for unit tests outside of the package
@@ -155,7 +156,7 @@ public class SeqGoTrip extends NextfareTrip {
     private static Station getStation(int stationId) {
         if (stationId <= 0) return null;
 
-        StationTableReader str = MetrodroidApplication.getInstance().getSeqGoSTR();
+        StationTableReader str = StationTableReader.getSTR(SEQ_GO_STR);
         if (str == null) return null;
 
         try {

--- a/src/main/java/au/id/micolous/metrodroid/transit/suica/SuicaDBUtil.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/suica/SuicaDBUtil.java
@@ -30,6 +30,8 @@ import au.id.micolous.metrodroid.util.StationTableReader;
 
 final class SuicaDBUtil {
     private static final String TAG = "SuicaUtil";
+    private static final String SUICA_BUS_STR = "suica_bus";
+    private static final String SUICA_RAIL_STR = "suica_rail";
 
     /**
      * Gets bus stop information from the IruCa (イルカ) table.
@@ -46,7 +48,7 @@ final class SuicaDBUtil {
         int stationId = (lineCode << 8) + stationCode;
         if (stationId == 0) return null;
 
-        StationTableReader str = MetrodroidApplication.getInstance().getSuicaBusSTR();
+        StationTableReader str = StationTableReader.getSTR(SUICA_BUS_STR);
         if (str == null) return null;
 
         try {
@@ -74,7 +76,7 @@ final class SuicaDBUtil {
         int stationId = (areaCode << 16) + (lineCode << 8) + stationCode;
         if (stationId == 0) return null;
 
-        StationTableReader str = MetrodroidApplication.getInstance().getSuicaRailSTR();
+        StationTableReader str = StationTableReader.getSTR(SUICA_RAIL_STR);
         if (str == null) return null;
 
         try {


### PR DESCRIPTION
This allows avoid to change MetrodroidApplication every time a new DB is needed.