### PR TITLE
Add option to always show raw station IDs

### DIFF
--- a/src/main/java/au/id/micolous/metrodroid/MetrodroidApplication.java
+++ b/src/main/java/au/id/micolous/metrodroid/MetrodroidApplication.java
@@ -91,6 +91,7 @@ public class MetrodroidApplication extends Application {
 
     private static final Set<String> devicesMifareWorks = new HashSet<>();
     private static final Set<String> devicesMifareNotWorks = new HashSet<>();
+    private static final String PREF_SHOW_RAW_IDS = "pref_show_raw_ids";
 
     static {
         devicesMifareWorks.add("Pixel 2");
@@ -258,5 +259,10 @@ public class MetrodroidApplication extends Application {
         if (theme.equals("farebot"))
             return R.style.FareBot_Theme_Common;
         return R.style.Metrodroid_Dark;
+    }
+
+    public static boolean showRawStationIds() {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(MetrodroidApplication.getInstance());
+        return prefs.getBoolean(MetrodroidApplication.PREF_SHOW_RAW_IDS, false);
     }
 }

--- a/src/main/java/au/id/micolous/metrodroid/transit/clipper/ClipperData.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/clipper/ClipperData.java
@@ -65,7 +65,9 @@ final class ClipperData {
     }
 
     public static Station getStation(int agency, int stationId, boolean isEnd) {
-        Station s = StationTableReader.getStationNoFallback(CLIPPER_STR,(agency << 16) | stationId);
+        String humanReadableId = "0x" + Integer.toHexString(agency) + "/0x" + Integer.toHexString(stationId);
+        Station s = StationTableReader.getStationNoFallback(CLIPPER_STR,(agency << 16) | stationId,
+                humanReadableId);
         if (s != null)
             return s;
 
@@ -79,6 +81,6 @@ final class ClipperData {
         if (stationId == (isEnd ? 0xffff : 0))
             return null;
 
-        return Station.unknown("0x" + Integer.toHexString(agency) + "/0x" + Long.toString(stationId, 16));
+        return Station.unknown(humanReadableId);
     }
 }

--- a/src/main/java/au/id/micolous/metrodroid/transit/newshenzhen/NewShenzhenTrip.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/newshenzhen/NewShenzhenTrip.java
@@ -97,23 +97,12 @@ public class NewShenzhenTrip extends Trip {
         int transport = getTransport();
         switch (transport) {
             case SZT_METRO:
-                return addGateNumber(getStation(mStation & ~0xff),
-                        Integer.toHexString((int)(mStation & 0xff)));
+                return getStation(mStation & ~0xff).addAttribute(
+                        Utils.localizeString(R.string.szt_station_gate,
+                                Integer.toHexString((int)(mStation & 0xff))));
             default:
                 return null;
         }
-    }
-
-    private static Station addGateNumber(Station station, String gate) {
-        return new Station(
-                station.getCompanyName(),
-                station.getLineName(),
-                Utils.localizeString(R.string.szt_station_gate,
-                        station.getStationName(), gate),
-                station.getShortStationName(),
-                station.getLatitude(),
-                station.getLongitude(),
-                station.getLanguage());
     }
 
     @Nullable

--- a/src/main/java/au/id/micolous/metrodroid/transit/newshenzhen/NewShenzhenTrip.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/newshenzhen/NewShenzhenTrip.java
@@ -60,8 +60,8 @@ public class NewShenzhenTrip extends Trip {
     private final long mStation;
     private final static String SHENZHEN_STR = "shenzhen";
 
-    private static Station getStation(long l) {
-        return StationTableReader.getStation(SHENZHEN_STR, (int) l);
+    private static Station getStation(long l, String humanReadableId) {
+        return StationTableReader.getStation(SHENZHEN_STR, (int) l, humanReadableId);
     }
 
 
@@ -97,7 +97,8 @@ public class NewShenzhenTrip extends Trip {
         int transport = getTransport();
         switch (transport) {
             case SZT_METRO:
-                return getStation(mStation & ~0xff).addAttribute(
+                return StationTableReader.getStation(SHENZHEN_STR, (int) (mStation & ~0xff),
+                        Long.toHexString(mStation >> 8)).addAttribute(
                         Utils.localizeString(R.string.szt_station_gate,
                                 Integer.toHexString((int)(mStation & 0xff))));
             default:

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -839,7 +839,7 @@
     <string name="card_name_octopus_szt_dual">Hu Tong Xing</string>
     <string name="szt_metro">Shenzhen Metro</string>
     <string name="szt_bus">Shenzhen Bus</string>
-    <string name="szt_station_gate">%s, gate %s</string>
+    <string name="szt_station_gate">gate %s</string>
 
     <!--
         Bilhete Único
@@ -934,4 +934,6 @@
     <string name="mfc_not_supported">MIFARE Classic: not supported</string>
     <string name="balances_and_subscriptions">Tickets</string>
     <string name="card_number">Card number</string>
+    <string name="pref_show_raw_station_ids">Show raw station IDs</string>
+    <string name="pref_show_raw_station_ids_desc">If true, a raw station ID is shown in addition to station name</string>
 </resources>

--- a/src/main/res/xml/prefs.xml
+++ b/src/main/res/xml/prefs.xml
@@ -134,5 +134,11 @@
             android:summary="@string/pref_show_local_and_english_desc"
             android:key="pref_show_local_and_english"
             android:defaultValue="false" />
+
+        <CheckBoxPreference
+            android:title="@string/pref_show_raw_station_ids"
+            android:summary="@string/pref_show_raw_station_ids_desc"
+            android:key="pref_show_raw_ids"
+            android:defaultValue="false" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
This is useful when debugging or collecting database

While on it add a generic way to add "attributes" to stations, like e.g.
gate number. This will be reused in, at least, Podorozhnik.