### PR TITLE
Remove the need to always override hasTime

### DIFF
--- a/src/main/java/au/id/micolous/metrodroid/fragment/CardTripsFragment.java
+++ b/src/main/java/au/id/micolous/metrodroid/fragment/CardTripsFragment.java
@@ -271,8 +271,8 @@ public class CardTripsFragment extends ListFragment {
                 iconImageView.setContentDescription(s);
             }
 
-            if (trip.hasTime()) {
-                Calendar end = trip.getEndTimestamp();
+            Calendar end = trip.getEndTimestamp();
+            if (trip.hasTime() && (start != null || end != null)) {
                 if (end != null && start != null)
                     timeTextView.setText(Utils.localizeString(R.string.time_from_to, Utils.timeFormat(start), Utils.timeFormat(end)));
                 else if (start != null)

--- a/src/main/java/au/id/micolous/metrodroid/transit/Trip.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/Trip.java
@@ -308,7 +308,9 @@ public abstract class Trip implements Parcelable {
      *
      * @return true if a time of day should be displayed.
      */
-    public abstract boolean hasTime();
+    public boolean hasTime() {
+	return true;
+    }
 
     public enum Mode {
         BUS(0),

--- a/src/main/java/au/id/micolous/metrodroid/transit/clipper/ClipperRefill.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/clipper/ClipperRefill.java
@@ -98,11 +98,6 @@ public class ClipperRefill extends Trip implements Comparable {
     }
 
     @Override
-    public boolean hasTime() {
-        return true;
-    }
-
-    @Override
     public int describeContents() {
         return 0;
     }

--- a/src/main/java/au/id/micolous/metrodroid/transit/clipper/ClipperTrip.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/clipper/ClipperTrip.java
@@ -129,11 +129,6 @@ public class ClipperTrip extends Trip {
         return ClipperData.getMode(mAgency);
     }
 
-    @Override
-    public boolean hasTime() {
-        return true;
-    }
-
     public void writeToParcel(Parcel parcel, int flags) {
         Utils.parcelCalendar(parcel, mTimestamp);
         Utils.parcelCalendar(parcel, mExitTimestamp);

--- a/src/main/java/au/id/micolous/metrodroid/transit/compass/CompassUltralightTrip.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/compass/CompassUltralightTrip.java
@@ -130,11 +130,6 @@ public class CompassUltralightTrip extends Trip implements Parcelable {
     }
 
     @Override
-    public boolean hasTime() {
-        return getStartTimestamp() != null || getEndTimestamp() != null;
-    }
-
-    @Override
     public int describeContents() {
         return 0;
     }

--- a/src/main/java/au/id/micolous/metrodroid/transit/edy/EdyTrip.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/edy/EdyTrip.java
@@ -139,10 +139,6 @@ public class EdyTrip extends Trip {
         return str;
     }
 
-    public boolean hasTime() {
-        return mTimestamp != null;
-    }
-
     // unused
     public String getRouteName() {
         return null;

--- a/src/main/java/au/id/micolous/metrodroid/transit/erg/ErgTrip.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/erg/ErgTrip.java
@@ -92,11 +92,6 @@ public class ErgTrip extends Trip {
     }
 
     @Override
-    public boolean hasTime() {
-        return true;
-    }
-
-    @Override
     public int describeContents() {
         return 0;
     }

--- a/src/main/java/au/id/micolous/metrodroid/transit/ezlink/EZLinkTrip.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/ezlink/EZLinkTrip.java
@@ -167,11 +167,6 @@ public class EZLinkTrip extends Trip {
         return Mode.OTHER;
     }
 
-    @Override
-    public boolean hasTime() {
-        return true;
-    }
-
     public void writeToParcel(Parcel parcel, int flags) {
         parcel.writeParcelable(mTransaction, flags);
     }

--- a/src/main/java/au/id/micolous/metrodroid/transit/hsl/HSLRefill.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/hsl/HSLRefill.java
@@ -89,10 +89,4 @@ public class HSLRefill extends Trip implements Parcelable {
     public Mode getMode() {
         return Mode.TICKET_MACHINE;
     }
-
-    @Override
-    public boolean hasTime() {
-        return true;
-    }
-
 }

--- a/src/main/java/au/id/micolous/metrodroid/transit/newshenzhen/NewShenzhenTrip.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/newshenzhen/NewShenzhenTrip.java
@@ -154,11 +154,6 @@ public class NewShenzhenTrip extends Trip {
     }
 
     @Override
-    public boolean hasTime() {
-        return true;
-    }
-
-    @Override
     public Calendar getStartTimestamp() {
         int transport = getTransport();
         if (transport == SZT_METRO)

--- a/src/main/java/au/id/micolous/metrodroid/transit/orca/OrcaTrip.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/orca/OrcaTrip.java
@@ -167,11 +167,6 @@ public class OrcaTrip extends Trip {
         return Mode.BUS;
     }
 
-    @Override
-    public boolean hasTime() {
-        return true;
-    }
-
     public void writeToParcel(Parcel parcel, int flags) {
         parcel.writeLong(mTimestamp);
         parcel.writeInt(mCoachNum);

--- a/src/main/java/au/id/micolous/metrodroid/transit/ovc/OVChipTrip.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/ovc/OVChipTrip.java
@@ -286,10 +286,6 @@ public class OVChipTrip extends Trip {
         return mExitTimestamp;
     }
 
-    public boolean hasTime() {
-        return (mTimestamp != null);
-    }
-
     @Nullable
     @Override
     public TransitCurrency getFare() {

--- a/src/main/java/au/id/micolous/metrodroid/transit/ravkav/RavKavTrip.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/ravkav/RavKavTrip.java
@@ -144,11 +144,6 @@ class RavKavTrip extends Trip {
     }
 
     @Override
-    public boolean hasTime() {
-        return true;
-    }
-
-    @Override
     public int describeContents() {
         return 0;
     }

--- a/src/main/java/au/id/micolous/metrodroid/transit/smartrider/SmartRiderTrip.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/smartrider/SmartRiderTrip.java
@@ -94,11 +94,6 @@ public class SmartRiderTrip extends Trip {
     }
 
     @Override
-    public boolean hasTime() {
-        return mStartTime != null;
-    }
-
-    @Override
     public Calendar getStartTimestamp() {
         return mStartTime;
     }

--- a/src/main/java/au/id/micolous/metrodroid/transit/tmoney/TMoneyTrip.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/tmoney/TMoneyTrip.java
@@ -88,11 +88,6 @@ public class TMoneyTrip extends Trip {
         }
     }
 
-    @Override
-    public boolean hasTime() {
-        return mTime != INVALID_DATETIME;
-    }
-
     private static Calendar parseHexDateTime(long val) {
         if (val == INVALID_DATETIME)
             return null;

--- a/src/main/java/au/id/micolous/metrodroid/transit/troika/TroikaTrip.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/troika/TroikaTrip.java
@@ -174,9 +174,4 @@ class TroikaTrip extends Trip {
                 return Mode.TRAIN;
         }
     }
-
-    @Override
-    public boolean hasTime() {
-        return true;
-    }
 }


### PR DESCRIPTION
Only very few cards store day but not time. So change logic to
automatically detect null datetime as hasTime = null and leave override only
when really necessarry.