### PR TITLE
Mark empty sector on Mifare Classic as such

### DIFF
--- a/src/main/java/au/id/micolous/metrodroid/card/classic/ClassicBlock.java
+++ b/src/main/java/au/id/micolous/metrodroid/card/classic/ClassicBlock.java
@@ -67,4 +67,13 @@ public class ClassicBlock {
     public byte[] getData() {
         return mData.getData();
     }
+
+    private static final String ZERO = "AAAAAAAAAAAAAAAAAAAAAA==";
+    private static final String FF = "/////////////////////w==";
+    private static final String ZERO_VB = "AAAAAP////8AAAAAAP8A/w==";
+
+    public boolean isEmpty() {
+        String actual = mData.toBase64();
+        return actual.equals(ZERO) || actual.equals(FF) || actual.equals(ZERO_VB);
+    }
 }

--- a/src/main/java/au/id/micolous/metrodroid/card/classic/ClassicSector.java
+++ b/src/main/java/au/id/micolous/metrodroid/card/classic/ClassicSector.java
@@ -84,4 +84,21 @@ public class ClassicSector {
         }
         return data;
     }
+
+    public boolean isEmpty() {
+        try {
+            List<ClassicBlock> blocks = getBlocks();
+            for (ClassicBlock block : blocks) {
+                if (getIndex() == 0 && block.getIndex() == 0)
+                    continue;
+                if (block.getIndex() == blocks.size() - 1)
+                    continue;
+                if (!block.isEmpty())
+                    return false;
+            }
+        } catch (Exception e) {
+            return true;
+        }
+        return true;
+    }
 }

--- a/src/main/java/au/id/micolous/metrodroid/fragment/ClassicCardRawDataFragment.java
+++ b/src/main/java/au/id/micolous/metrodroid/fragment/ClassicCardRawDataFragment.java
@@ -137,6 +137,8 @@ public class ClassicCardRawDataFragment extends ExpandableListFragment {
                 textView.setText(mActivity.getString(R.string.unauthorized_sector_title_format, sectorIndexString));
             } else if (sector instanceof InvalidClassicSector) {
                 textView.setText(mActivity.getString(R.string.invalid_sector_title_format, sectorIndexString, ((InvalidClassicSector) sector).getError()));
+            } else if (sector.isEmpty()) {
+                textView.setText(mActivity.getString(R.string.sector_title_format_empty, sectorIndexString));
             } else {
                 textView.setText(mActivity.getString(R.string.sector_title_format, sectorIndexString));
             }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -98,6 +98,7 @@
     <string name="unauthorized_page_title_format">Page: 0x%s (unauthorized)</string>
     <string name="sector_title_format">Sector: 0x%s</string>
     <string name="unauthorized_sector_title_format">Sector: 0x%s (unauthorized)</string>
+    <string name="sector_title_format_empty">Sector: 0x%s (empty)</string>
     <string name="invalid_sector_title_format">Sector: 0x%1$s (invalid: %2$s)</string>
     <!-- Translators: the first parameter is a hexadecimal number, the second parameter is a string
     describing a "well known" system code. eg: "System: 0x3 (Suica)" -->


### PR DESCRIPTION
On some cards there are a lot of empty sectors which makes it
cumbersome to check that there is no new data in a new dump. So mark
empty sectors as such.