### PR TITLE
Add missing os.close()

### DIFF
--- a/src/main/java/au/id/micolous/metrodroid/activity/AdvancedCardInfoActivity.java
+++ b/src/main/java/au/id/micolous/metrodroid/activity/AdvancedCardInfoActivity.java
@@ -196,6 +196,7 @@ public class AdvancedCardInfoActivity extends MetrodroidActivity {
                         OutputStream os = getContentResolver().openOutputStream(uri);
                         xml = mCard.toXml(MetrodroidApplication.getInstance().getSerializer());
                         IOUtils.write(xml, os, Charset.defaultCharset());
+                        os.close();
                         Toast.makeText(this, R.string.saved_xml_custom, Toast.LENGTH_SHORT).show();
                         break;
                 }


### PR DESCRIPTION
Without it exporting a single card to google drive results in zero-sized file.