### PR TITLE
Add Kitsap Transit to ORCA

### DIFF
--- a/data/orca/agencies.csv
+++ b/data/orca/agencies.csv
@@ -2,6 +2,7 @@ id,name,short_name,mode
 2,Community Transit,CT,BUS
 3,Everett Transit,ET,BUS
 4,King County Metro Transit,KCM,BUS
+5,Kitsap Transit,KT,BUS
 6,Pierce Transit,PT,BUS
 7,Sound Transit,ST,TRAIN
 8,Washington State Ferries,WSF,FERRY


### PR DESCRIPTION
Rode two buses and the fast ferry (using a [PFTP](https://www.flickr.com/photos/viriyincy/3561731244/)); all showed up as agency 5.