### PR TITLE
When trying alternate static keys dedup them.

### DIFF
--- a/src/main/java/au/id/micolous/metrodroid/key/ClassicStaticKeys.java
+++ b/src/main/java/au/id/micolous/metrodroid/key/ClassicStaticKeys.java
@@ -30,6 +30,7 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -140,11 +141,15 @@ public class ClassicStaticKeys extends ClassicCardKeys {
     @NonNull
     @Override
     public List<ClassicSectorKey> keys() {
-        List<ClassicSectorKey> allKeys = new ArrayList<>();
+        HashSet<String> allKeys = new HashSet<>();
         for (List<ClassicSectorKeyWrapper> keys : mKeys.values()) {
-            allKeys.addAll(keys);
+            for (ClassicSectorKeyWrapper key : keys)
+                allKeys.add(Utils.getHexString(key.getKey()));
         }
-        return allKeys;
+        ArrayList<ClassicSectorKey> uniqueKeys = new ArrayList<>();
+        for (String key : allKeys)
+            uniqueKeys.add(ClassicSectorKey.wellKnown(Utils.hexStringToByteArray(key)));
+        return uniqueKeys;
     }
 
     @Override
@@ -159,10 +164,12 @@ public class ClassicStaticKeys extends ClassicCardKeys {
     }
 
     public String getFileType() {
-        int keyCount = 0;
+        HashSet<String> allKeys = new HashSet<>();
         for (List<ClassicSectorKeyWrapper> keys : mKeys.values()) {
-            keyCount += keys.size();
+            for (ClassicSectorKeyWrapper key : keys)
+                allKeys.add(Utils.getHexString(key.getKey()));
         }
+        int keyCount = allKeys.size();
 
         return Utils.localizePlural(R.plurals.keytype_mfc_static, keyCount, keyCount);
     }


### PR DESCRIPTION
Many keys are repeated in static keysets, no need to try them a lot of times.