### PR TITLE
Add Oppo Find7 to whitelist - device is working here after whitelisting

### DIFF
--- a/src/main/java/au/id/micolous/metrodroid/MetrodroidApplication.java
+++ b/src/main/java/au/id/micolous/metrodroid/MetrodroidApplication.java
@@ -98,6 +98,7 @@ public class MetrodroidApplication extends Application {
 
     static {
         devicesMifareWorks.add("Pixel 2");
+        devicesMifareWorks.add("Find7");
     }
 
     private static MetrodroidApplication sInstance;


### PR DESCRIPTION
My Oppo Find 7 device (running LineageOS) is not working with the unpatched version as Metrodroid says that Mifare Classic support is not there.

After whitelisting, my device can read cards without problems.