### PR TITLE
Fix OVChipkaart credit

### DIFF
--- a/src/main/java/au/id/micolous/metrodroid/transit/ovc/OVChipCredit.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/ovc/OVChipCredit.java
@@ -64,7 +64,12 @@ public class OVChipCredit implements Parcelable {
         banbits = Utils.getBitsFromBuffer(data, 0, 9);
         id = Utils.getBitsFromBuffer(data, 9, 12);
         creditId = Utils.getBitsFromBuffer(data, 56, 12);
-        credit = Utils.getBitsFromBufferSigned(data, 77, 16);
+        credit = Utils.getBitsFromBuffer(data, 78, 15);    // Skipping the first bit (77)...
+
+        if ((data[9] & (byte) 0x04) != 4) {    // ...as the first bit is used to see if the credit is negative or not
+            credit ^= (char) 0x7FFF;
+            credit = credit * -1;
+        }
 
         mId = id;
         mCreditId = creditId;


### PR DESCRIPTION
The OVChipkaart credit amount was broken by e3f115afcf9c2e0990535303f376aef885eba972.

This commit reverts the change.