### PR TITLE
Fix potential crash due to reusing view of incorrect type.

### DIFF
--- a/src/main/java/au/id/micolous/metrodroid/fragment/CardBalanceFragment.java
+++ b/src/main/java/au/id/micolous/metrodroid/fragment/CardBalanceFragment.java
@@ -57,6 +57,10 @@ public class CardBalanceFragment extends ListFragment {
     private TransitData mTransitData;
     private static final String TAG = "CardBalanceFragment";
 
+    private static final String TAG_BALANCE_VIEW = "balanceView";
+    private static final String TAG_SUBSCRIPTION_VIEW = "subscriptionView";
+    private static final String TAG_ERROR_VIEW = "errorView";
+
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         mTransitData = getArguments().getParcelable(CardInfoActivity.EXTRA_TRANSIT_DATA);
@@ -100,8 +104,9 @@ public class CardBalanceFragment extends ListFragment {
 
         private View getErrorView(View convertView, ViewGroup parent, String err) {
             View view = convertView;
-            if (view == null) {
+            if (view == null || view.getTag() != TAG_ERROR_VIEW) {
                 view = getActivity().getLayoutInflater().inflate(R.layout.balance_item, parent, false);
+                view.setTag(TAG_ERROR_VIEW);
             }
 
             ((TextView) view.findViewById(R.id.balance)).setText(err);
@@ -110,8 +115,9 @@ public class CardBalanceFragment extends ListFragment {
 
         public View getSubscriptionView(View convertView, ViewGroup parent, Subscription subscription) {
             View view = convertView;
-            if (view == null) {
+            if (view == null || view.getTag() != TAG_SUBSCRIPTION_VIEW) {
                 view = getActivity().getLayoutInflater().inflate(R.layout.subscription_item, parent, false);
+                view.setTag(TAG_SUBSCRIPTION_VIEW);
             }
 
             TextView validView = view.findViewById(R.id.valid);
@@ -219,8 +225,9 @@ public class CardBalanceFragment extends ListFragment {
         private View getBalanceView(View convertView,
                                     ViewGroup parent, TransitBalance balance) {
             View view = convertView;
-            if (view == null) {
+            if (view == null || view.getTag() != TAG_BALANCE_VIEW) {
                 view = getActivity().getLayoutInflater().inflate(R.layout.balance_item, parent, false);
+                view.setTag(TAG_BALANCE_VIEW);
             }
 
             TextView validView = view.findViewById(R.id.valid);


### PR DESCRIPTION
If a card has many subscriptions, it can happen that view are reused (convertView is non-null).
If a BalanceView is reused as a SubscriptionView (or vice versa), this leads to a crash of the
application as findById returns null for sub-views.

When a card does not have many subscriptions, the bug is not triggered here, as the views are
not reused.

I used getTag()/setTag() to mark the views and check whether they are the correct type. An easier
fix would be to always discard "convertView". You could also check for a unique view id with
findById(), but IMHO this is more error-prone.


Error I get when view is reused incorrectly:

java.lang.NullPointerException: Attempt to invoke virtual method 'void android.widget.TextView.setVisibility(int)' on a null object reference
        at au.id.micolous.metrodroid.fragment.CardBalanceFragment$BalancesAdapter.getSubscriptionView(CardBalanceFragment.java:158)
        at au.id.micolous.metrodroid.fragment.CardBalanceFragment$BalancesAdapter.getView(CardBalanceFragment.java:97)
        at android.widget.AbsListView.obtainView(AbsListView.java:2365)
        at android.widget.ListView.makeAndAddView(ListView.java:2052)
        at android.widget.ListView.fillDown(ListView.java:786)
        at android.widget.ListView.fillGap(ListView.java:750)
        at android.widget.AbsListView.trackMotionScroll(AbsListView.java:5225)
        at android.widget.ListView.trackMotionScroll(ListView.java:1971)
        at android.widget.AbsListView$FlingRunnable.run(AbsListView.java:4769)
        at android.view.Choreographer$CallbackRecord.run(Choreographer.java:911)
        at android.view.Choreographer.doCallbacks(Choreographer.java:723)
        at android.view.Choreographer.doFrame(Choreographer.java:655)
        at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:897)
        at android.os.Handler.handleCallback(Handler.java:790)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:164)
        at android.app.ActivityThread.main(ActivityThread.java:6494)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:440)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)
