### PR TITLE
TransitCurrency: switch to integer math

### DIFF
--- a/src/androidTest/java/au/id/micolous/metrodroid/test/TransitCurrencyTest.java
+++ b/src/androidTest/java/au/id/micolous/metrodroid/test/TransitCurrencyTest.java
@@ -180,7 +180,7 @@ public class TransitCurrencyTest extends BaseInstrumentedTest {
     public void testNumericLookup() {
         setLocale("en-US");
 
-        TransitCurrency c = new TransitCurrency(1234, 36, 100.);
+        TransitCurrency c = new TransitCurrency(1234, 36, 100);
         assertEquals(TransitCurrency.AUD(1234), c);
 
         // Test with an invalid code
@@ -203,11 +203,11 @@ public class TransitCurrencyTest extends BaseInstrumentedTest {
         assertSpannedThat(c.formatCurrencyString(false), Matchers.endsWith("¥12.34"));
 
         // Test with different divisors for equality
-        c = new TransitCurrency(12340, "AUD", 1000.);
+        c = new TransitCurrency(12340, "AUD", 1000);
         assertEquals(TransitCurrency.AUD(1234), c);
 
         // Test overriding the divisor in a currency code.
-        c = new TransitCurrency(12340, 36, 1000.);
+        c = new TransitCurrency(12340, 36, 1000);
         assertEquals(TransitCurrency.AUD(1234), c);
     }
 }

--- a/src/main/java/au/id/micolous/metrodroid/transit/rkf/RkfLookup.kt
+++ b/src/main/java/au/id/micolous/metrodroid/transit/rkf/RkfLookup.kt
@@ -34,11 +34,11 @@ const val STR = "rkf"
 data class RkfLookup (val mCurrencyCode : Int, val mCompany : Int) : En1545LookupSTR(STR), Parcelable {
     override fun parseCurrency(price: Int) : TransitCurrency {
         val intendedDivisor = when (mCurrencyCode shr 12) {
-            0 -> 1.0
-            1 -> 10.0
-            2 -> 100.0
-            9 -> 2.0
-            else -> 1.0
+            0 -> 1
+            1 -> 10
+            2 -> 100
+            9 -> 2
+            else -> 1
         }
 
         return TransitCurrency(price,

--- a/src/main/java/au/id/micolous/metrodroid/util/Utils.java
+++ b/src/main/java/au/id/micolous/metrodroid/util/Utils.java
@@ -954,6 +954,23 @@ public class Utils {
         return ret.toString();
     }
 
+    public static int log10floor(int val) {
+        int mul = 1;
+        int ctr = 0;
+        while (val >= 10 * mul) {
+            ctr++;
+            mul *= 10;
+        }
+        return ctr;
+    }
+
+    public static long pow(int a, int b) {
+        long ret = 1;
+        for (int i = 0 ; i < b; i++)
+            ret *= a;
+        return ret;
+    }
+
     public static String xmlNodeToString(Node node) throws TransformerException {
         return xmlNodeToString(node, true);
     }


### PR DESCRIPTION
Comparison between doubles is unpredictable. Use integer as much as possible.