### PR TITLE
Allow zip64 in farebotxml_to_files

### DIFF
--- a/extra/farebotxml_to_files.py
+++ b/extra/farebotxml_to_files.py
@@ -67,7 +67,7 @@ def zipify(input_xml, output_zipf, mfcdump, mobib):
   if mobib:
       output_zipf = codecs.getwriter('ascii')(output_zipf)
   elif not mfcdump:
-    output_zip = ZipFile(output_zipf, 'w')
+    output_zip = ZipFile(output_zipf, 'w', allowZip64 = True)
   xml = objectify.parse(input_xml)
   root = xml.getroot()
   if root.tag == 'cards':


### PR DESCRIPTION
Without zip64 we're limited to just a few thousand files which
can be easily hit if you have a lot of ultralight scans