### PR TITLE
Remove double brace initialization

### DIFF
--- a/src/main/java/au/id/micolous/metrodroid/transit/lax_tap/LaxTapData.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/lax_tap/LaxTapData.java
@@ -39,11 +39,13 @@ public final class LaxTapData {
      * as the card differentiates codes based on direction (GTFS does not), GTFS data merges several
      * routes together as one, and there aren't that many bus routes that Metro run.
      */
-    static final SparseArray<String> METRO_BUS_ROUTES = new SparseArray<String>() {{
-        put(32788, "733 East");
-        put(32952, "720 West");
-        put(33055, "733 West");
-    }};
+    static final SparseArray<String> METRO_BUS_ROUTES = new SparseArray<>() ;
+
+    static {
+        METRO_BUS_ROUTES.put(32788, "733 East");
+        METRO_BUS_ROUTES.put(32952, "720 West");
+        METRO_BUS_ROUTES.put(33055, "733 West");
+    }
 
     private LaxTapData() {
     }

--- a/src/main/java/au/id/micolous/metrodroid/transit/seq_go/SeqGoData.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/seq_go/SeqGoData.java
@@ -42,11 +42,13 @@ public final class SeqGoData {
 
     private static final int TICKET_TYPE_CONCESSION_2016 = 0x08a5;
 
-    static final SparseArray<SeqGoTicketType> TICKET_TYPE_MAP = new SparseArray<SeqGoTicketType>() {{
-        put(TICKET_TYPE_REGULAR_2011, SeqGoTicketType.REGULAR);
-        put(TICKET_TYPE_REGULAR_2016, SeqGoTicketType.REGULAR);
-        put(TICKET_TYPE_CONCESSION_2016, SeqGoTicketType.CONCESSION);
-    }};
+    static final SparseArray<SeqGoTicketType> TICKET_TYPE_MAP = new SparseArray<>();
+
+    static {
+        TICKET_TYPE_MAP.put(TICKET_TYPE_REGULAR_2011, SeqGoTicketType.REGULAR);
+        TICKET_TYPE_MAP.put(TICKET_TYPE_REGULAR_2016, SeqGoTicketType.REGULAR);
+        TICKET_TYPE_MAP.put(TICKET_TYPE_CONCESSION_2016, SeqGoTicketType.CONCESSION);
+    };
 
     private SeqGoData() {
     }


### PR DESCRIPTION
It needlessly creates a new child class rather than just an instance of base
class