### PR TITLE
Kill unused en1545 strings.

### DIFF
--- a/src/main/java/au/id/micolous/metrodroid/transit/en1545/Calypso1545TransitData.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/en1545/Calypso1545TransitData.java
@@ -36,12 +36,6 @@ import au.id.micolous.metrodroid.transit.Trip;
 import au.id.micolous.metrodroid.util.Utils;
 
 public abstract class Calypso1545TransitData extends En1545TransitData {
-    protected final static String CONTRACTS_PROVIDER = "ContractsProvider";
-    protected static final String CONTRACTS_POINTER = "ContractsPointer";
-    protected static final String CONTRACTS_TARIFF = "ContractsTariff";
-    protected static final String CONTRACTS_UNKNOWN_A = "ContractsUnknownA";
-    protected static final String CONTRACTS_UNKNOWN_B = "ContractsUnknownB";
-    protected static final String CONTRACTS_NETWORK_ID = "ContractsNetworkId";
     private final int mNetworkId;
     private final List<Trip> mTrips;
     private final List<En1545Subscription> mSubscriptions;


### PR DESCRIPTION
They're already in parent class