### PR TITLE
Allow iso7816 dumptag to return several applications.

### DIFF
--- a/src/main/java/au/id/micolous/metrodroid/card/calypso/CalypsoApplication.java
+++ b/src/main/java/au/id/micolous/metrodroid/card/calypso/CalypsoApplication.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Collection;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
@@ -123,7 +124,7 @@ public class CalypsoApplication extends ISO7816Application {
 
         @NonNull
         @Override
-        public ISO7816Application dumpTag(@NonNull ISO7816Protocol protocol, @NonNull ISO7816Info appData, @NonNull TagReaderFeedbackInterface feedbackInterface) {
+        public List<ISO7816Application> dumpTag(@NonNull ISO7816Protocol protocol, @NonNull ISO7816Info appData, @NonNull TagReaderFeedbackInterface feedbackInterface) {
             // At this point, the connection is already open, we just need to dump the right things...
 
             feedbackInterface.updateStatusText(Utils.localizeString(R.string.calypso_reading));
@@ -153,7 +154,7 @@ public class CalypsoApplication extends ISO7816Application {
                 }
             }
 
-            return new CalypsoApplication(appData, partialRead);
+            return Collections.singletonList(new CalypsoApplication(appData, partialRead));
         }
     };
 

--- a/src/main/java/au/id/micolous/metrodroid/card/china/ChinaCard.java
+++ b/src/main/java/au/id/micolous/metrodroid/card/china/ChinaCard.java
@@ -170,7 +170,7 @@ public class ChinaCard extends ISO7816Application {
          */
         @Nullable
         @Override
-        public ISO7816Application dumpTag(@NonNull ISO7816Protocol protocol, @NonNull ISO7816Info appData, @NonNull TagReaderFeedbackInterface feedbackInterface) {
+        public List<ISO7816Application> dumpTag(@NonNull ISO7816Protocol protocol, @NonNull ISO7816Info appData, @NonNull TagReaderFeedbackInterface feedbackInterface) {
             List <Balance> bals = new ArrayList<>();
 
             try {
@@ -226,7 +226,7 @@ public class ChinaCard extends ISO7816Application {
                 return null;
             }
 
-            return new ChinaCard(appData, bals);
+            return Collections.singletonList(new ChinaCard(appData, bals));
         }
     };
 

--- a/src/main/java/au/id/micolous/metrodroid/card/iso7816/ISO7816ApplicationFactory.java
+++ b/src/main/java/au/id/micolous/metrodroid/card/iso7816/ISO7816ApplicationFactory.java
@@ -26,9 +26,9 @@ public interface ISO7816ApplicationFactory {
     }
 
     @Nullable
-    ISO7816Application dumpTag(@NonNull ISO7816Protocol protocol,
-                               @NonNull ISO7816Application.ISO7816Info appData,
-                               @NonNull TagReaderFeedbackInterface feedbackInterface);
+    List<ISO7816Application> dumpTag(@NonNull ISO7816Protocol protocol,
+                                     @NonNull ISO7816Application.ISO7816Info appData,
+                                     @NonNull TagReaderFeedbackInterface feedbackInterface);
 
     @NonNls
     @NonNull

--- a/src/main/java/au/id/micolous/metrodroid/card/iso7816/ISO7816Card.java
+++ b/src/main/java/au/id/micolous/metrodroid/card/iso7816/ISO7816Card.java
@@ -126,7 +126,7 @@ public class ISO7816Card extends Card {
                         continue;
                     }
 
-                    ISO7816Application app = factory.dumpTag(
+                    List<ISO7816Application> app = factory.dumpTag(
                             iso7816Tag, new ISO7816Application.ISO7816Info(
                                     appData, appId, tag.getId(), factory.getType()),
                             feedbackInterface);
@@ -135,7 +135,7 @@ public class ISO7816Card extends Card {
                         continue;
                     }
 
-                    apps.add(app);
+                    apps.addAll(app);
 
                     if (stopAfterFirst) {
                         break;

--- a/src/main/java/au/id/micolous/metrodroid/card/tmoney/TMoneyCard.java
+++ b/src/main/java/au/id/micolous/metrodroid/card/tmoney/TMoneyCard.java
@@ -110,7 +110,7 @@ public class TMoneyCard extends ISO7816Application {
          */
         @Nullable
         @Override
-        public ISO7816Application dumpTag(@NonNull ISO7816Protocol protocol, @NonNull ISO7816Info appData, @NonNull TagReaderFeedbackInterface feedbackInterface) {
+        public List<ISO7816Application> dumpTag(@NonNull ISO7816Protocol protocol, @NonNull ISO7816Info appData, @NonNull TagReaderFeedbackInterface feedbackInterface) {
             byte[] balanceResponse;
 
             try {
@@ -142,8 +142,8 @@ public class TMoneyCard extends ISO7816Application {
                 return null;
             }
 
-            return new TMoneyCard(appData,
-                    Utils.byteArrayToInt(balanceResponse, 0, BALANCE_RESP_LEN));
+            return Collections.singletonList(new TMoneyCard(appData,
+                    Utils.byteArrayToInt(balanceResponse, 0, BALANCE_RESP_LEN)));
         }
 
         @Override


### PR DESCRIPTION
This is needed when entry-point app references another app by its ID
that is not known in advance