### PR TITLE
iso7816: remve getFiles

### DIFF
--- a/src/main/java/au/id/micolous/metrodroid/card/iso7816/ISO7816Application.java
+++ b/src/main/java/au/id/micolous/metrodroid/card/iso7816/ISO7816Application.java
@@ -239,10 +239,6 @@ public class ISO7816Application {
         }
     }
 
-    public List<ISO7816File> getFiles() {
-        return mFiles;
-    }
-
     public ISO7816File getFile(ISO7816Selector sel) {
         for (ISO7816File f : mFiles) {
             if (f.getSelector().equals(sel)) {


### PR DESCRIPTION
It's not actually useful and breaks encapsulation.