### PR TITLE
TLV improvements

### DIFF
--- a/src/main/java/au/id/micolous/metrodroid/card/iso7816/ISO7816Card.java
+++ b/src/main/java/au/id/micolous/metrodroid/card/iso7816/ISO7816Card.java
@@ -204,8 +204,8 @@ public class ISO7816Card extends Card {
             List<ListItem> rawAppData = new ArrayList<>();
             byte[] appData = app.getAppData();
             if (appData != null)
-                rawAppData.add(ListItemRecursive.collapsedValue(
-                        R.string.app_fci, Utils.getHexDump(appData)));
+                rawAppData.add(new ListItemRecursive(
+                        R.string.app_fci, null, ISO7816TLV.INSTANCE.infoWithRaw(appData)));
             rawAppData.addAll(app.getRawFiles());
             List<ListItem> extra = app.getRawData();
             if (extra != null)

--- a/src/main/java/au/id/micolous/metrodroid/card/iso7816/ISO7816File.java
+++ b/src/main/java/au/id/micolous/metrodroid/card/iso7816/ISO7816File.java
@@ -118,8 +118,8 @@ public class ISO7816File {
             recList.add(ListItemRecursive.collapsedValue(Utils.localizeString(R.string.binary_title_format),
                     Utils.getHexDump(binaryData)));
         if (fciData != null)
-            recList.add(ListItemRecursive.collapsedValue(Utils.localizeString(R.string.file_fci),
-                    Utils.getHexDump(fciData)));
+            recList.add(new ListItemRecursive(Utils.localizeString(R.string.file_fci), null,
+                    ISO7816TLV.INSTANCE.infoWithRaw(fciData)));
         List<ISO7816Record> records = getRecords();
         for (ISO7816Record record : records)
             recList.add(ListItemRecursive.collapsedValue(Utils.localizeString(R.string.record_title_format, record.getIndex()),

--- a/src/main/java/au/id/micolous/metrodroid/card/iso7816/ISO7816TLV.kt
+++ b/src/main/java/au/id/micolous/metrodroid/card/iso7816/ISO7816TLV.kt
@@ -1,0 +1,116 @@
+/*
+ * ISO7816TLV.java
+ *
+ * Copyright 2018 Michael Farrell <micolous+git@gmail.com>
+ * Copyright 2018 Google
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package au.id.micolous.metrodroid.card.iso7816
+
+import au.id.micolous.metrodroid.ui.ListItem
+import au.id.micolous.metrodroid.ui.ListItemRecursive
+import au.id.micolous.metrodroid.util.Utils
+import java.lang.Exception
+
+object ISO7816TLV {
+    // return: <leadBits, id, idlen>
+    private fun getTLVIDLen(buf: ByteArray, p: Int): Int {
+        if (buf[p].toInt() and 0x1f != 0x1f)
+            return 1
+        var len = 1
+        while (buf[p + len++].toInt() and 0x80 != 0);
+        return len
+    }
+
+    // return lenlen, lenvalue
+    private fun decodeTLVLen(buf: ByteArray, p: Int): IntArray {
+        val headByte = buf[p].toInt() and 0xff
+        if (headByte shr 7 == 0)
+            return intArrayOf(1, headByte and 0x7f)
+        val numfollowingbytes = headByte and 0x7f
+        return intArrayOf(1 + numfollowingbytes,
+                Utils.byteArrayToInt(buf, p + 1, numfollowingbytes))
+    }
+
+    fun berTlvIterate(buf: ByteArray,
+                              iterator: (id: ByteArray,
+                                         header: ByteArray,
+                                         data: ByteArray) -> Unit) {
+        // Skip ID
+        var p = getTLVIDLen(buf, 0)
+        val (startoffset, fulllen) = decodeTLVLen(buf, p)
+        p += startoffset
+
+        while (p < fulllen) {
+            val idlen = getTLVIDLen(buf, p)
+            val (lenlen, datalen) = decodeTLVLen(buf, p + idlen)
+            iterator(Utils.byteArraySlice(buf, p, idlen),
+                    Utils.byteArraySlice(buf, p, idlen + lenlen),
+                    Utils.byteArraySlice(buf, p + idlen + lenlen, datalen))
+
+            p += idlen + lenlen + datalen
+        }
+    }
+
+    fun pdolIterate(buf: ByteArray,
+                    iterator: (id: ByteArray,
+                               len: Int) -> Unit) {
+        var p = 0
+
+        while (p < buf.size) {
+            val idlen = getTLVIDLen(buf, p)
+            val (lenlen, datalen) = decodeTLVLen(buf, p + idlen)
+            iterator(Utils.byteArraySlice(buf, p, idlen), datalen)
+
+            p += idlen + lenlen
+        }
+    }
+
+    fun findBERTLV(buf: ByteArray, target: String, keepHeader: Boolean): ByteArray? {
+        var result: ByteArray? = null
+        berTlvIterate(buf) { id, header, data ->
+            if (Utils.getHexString(id) == target) {
+                result = if (keepHeader) header + data else data
+            }
+        }
+        return result
+    }
+
+    fun infoBerTLV(buf: ByteArray): List<ListItem> {
+        val result = mutableListOf<ListItem>()
+        berTlvIterate(buf) { id, header, data ->
+            if (id[0].toInt() and 0xe0 == 0xa0)
+                try {
+                    result.add(ListItemRecursive(Utils.getHexString(id),
+                            null, infoBerTLV(header + data)))
+                } catch (e: Exception) {
+                    result.add(ListItem(Utils.getHexDump(id), Utils.getHexDump(data)))
+                }
+            else
+                result.add(ListItem(Utils.getHexDump(id), Utils.getHexDump(data)))
+
+        }
+        return result
+    }
+
+    fun infoWithRaw(buf: ByteArray) = listOfNotNull(
+            ListItemRecursive.collapsedValue("RAW", Utils.getHexDump(buf)),
+            try {
+                ListItemRecursive("TLV", null, infoBerTLV(buf))
+            } catch (e: Exception) {
+                null
+            })
+}

--- a/src/main/java/au/id/micolous/metrodroid/transit/china/NewShenzhenTransitData.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/china/NewShenzhenTransitData.java
@@ -32,9 +32,9 @@ import java.util.List;
 import au.id.micolous.farebot.R;
 import au.id.micolous.metrodroid.card.CardType;
 import au.id.micolous.metrodroid.card.china.ChinaCardTransitFactory;
-import au.id.micolous.metrodroid.card.iso7816.ISO7816Application;
 import au.id.micolous.metrodroid.card.iso7816.ISO7816File;
 import au.id.micolous.metrodroid.card.china.ChinaCard;
+import au.id.micolous.metrodroid.card.iso7816.ISO7816TLV;
 import au.id.micolous.metrodroid.transit.CardInfo;
 import au.id.micolous.metrodroid.transit.TransitData;
 import au.id.micolous.metrodroid.transit.TransitIdentity;
@@ -133,10 +133,10 @@ public class NewShenzhenTransitData extends ChinaTransitData {
         ISO7816File file15 = getFile(card, 0x15);
         if (file15 != null)
             return file15.getBinaryData();
-        byte []szttag = ISO7816Application.findBERTLV(card.getAppData(), 5,  5, true);
+        byte []szttag = ISO7816TLV.INSTANCE.findBERTLV(card.getAppData(), "a5", true);
         if (szttag == null)
             return null;
-        return ISO7816Application.findBERTLV(szttag, 4,  0xc, false);
+        return ISO7816TLV.INSTANCE.findBERTLV(szttag, "8c", false);
     }
 
     private static int parseSerial(ChinaCard card) {

--- a/src/main/java/au/id/micolous/metrodroid/transit/tmoney/TMoneyTransitData.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/tmoney/TMoneyTransitData.java
@@ -26,14 +26,12 @@ import android.support.annotation.Nullable;
 import org.jetbrains.annotations.NonNls;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import au.id.micolous.farebot.R;
 import au.id.micolous.metrodroid.card.CardType;
-import au.id.micolous.metrodroid.card.iso7816.ISO7816Application;
 import au.id.micolous.metrodroid.card.iso7816.ISO7816Record;
-import au.id.micolous.metrodroid.card.iso7816.ISO7816Selector;
+import au.id.micolous.metrodroid.card.iso7816.ISO7816TLV;
 import au.id.micolous.metrodroid.card.tmoney.TMoneyCard;
 import au.id.micolous.metrodroid.transit.CardInfo;
 import au.id.micolous.metrodroid.transit.TransitCurrency;
@@ -133,7 +131,7 @@ public class TMoneyTransitData extends TransitData {
     }
 
     private static byte[] getSerialTag(TMoneyCard card) {
-        return ISO7816Application.findBERTLV(card.getAppData(), 5, 0x10, false);
+        return ISO7816TLV.INSTANCE.findBERTLV(card.getAppData(), "b0", false);
     }
 
     private static String parseSerial(TMoneyCard card) {


### PR DESCRIPTION
* Extract to separate class
* Convert to kotlin
* Use kotlin syntax to make it nicer and more reusable
* Add parsed FCI to raw tab
* Change ID to hex string. Current ID was done under false assumption that
  9f05 and 95 are the same. It's not the case, so use hex string, same as
  used in the documentation.