### PR TITLE
Card: Remove label from constructors

### DIFF
--- a/src/main/java/au/id/micolous/metrodroid/card/Card.java
+++ b/src/main/java/au/id/micolous/metrodroid/card/Card.java
@@ -73,18 +73,14 @@ public abstract class Card {
     }
 
     protected Card(CardType type, byte[] tagId, Calendar scannedAt) {
-        this(type, tagId, scannedAt, null);
+        this(type, tagId, scannedAt, false);
     }
 
-    protected Card(CardType type, byte[] tagId, Calendar scannedAt, String label) {
-        this(type, tagId, scannedAt, label, false);
-    }
-
-    protected Card(CardType type, byte[] tagId, Calendar scannedAt, String label, boolean partialRead) {
+    protected Card(CardType type, byte[] tagId, Calendar scannedAt, boolean partialRead) {
         mType = type;
         mTagId = new HexString(tagId);
         mScannedAt = scannedAt;
-        mLabel = label;
+        mLabel = null;
         mPartialRead = partialRead;
     }
 

--- a/src/main/java/au/id/micolous/metrodroid/card/classic/ClassicCard.java
+++ b/src/main/java/au/id/micolous/metrodroid/card/classic/ClassicCard.java
@@ -126,7 +126,7 @@ public class ClassicCard extends Card {
     }
 
     public ClassicCard(byte[] tagId, Calendar scannedAt, ClassicSector[] sectors, boolean partialRead) {
-        super(CardType.MifareClassic, tagId, scannedAt, null, partialRead);
+        super(CardType.MifareClassic, tagId, scannedAt, partialRead);
         mSectors = Arrays.asList(sectors);
     }
 

--- a/src/main/java/au/id/micolous/metrodroid/card/felica/FelicaCard.java
+++ b/src/main/java/au/id/micolous/metrodroid/card/felica/FelicaCard.java
@@ -85,7 +85,7 @@ public class FelicaCard extends Card {
     private FelicaCard() { /* For XML Serializer */ }
 
     public FelicaCard(byte[] tagId, Calendar scannedAt, boolean partialRead, byte[] idm, byte[] pmm, FelicaSystem[] systems) {
-        super(CardType.FeliCa, tagId, scannedAt, null, partialRead);
+        super(CardType.FeliCa, tagId, scannedAt, partialRead);
         mIDm = new Base64String(idm);
         mPMm = new Base64String(pmm);
         mSystems = Arrays.asList(systems);

--- a/src/main/java/au/id/micolous/metrodroid/card/iso7816/ISO7816Card.java
+++ b/src/main/java/au/id/micolous/metrodroid/card/iso7816/ISO7816Card.java
@@ -73,7 +73,7 @@ public class ISO7816Card extends Card {
     protected ISO7816Card() { /* For XML Serializer */ }
 
     public ISO7816Card(List<ISO7816Application> apps, byte[] tagId, Calendar scannedAt, boolean partialRead) {
-        super(CardType.ISO7816, tagId, scannedAt, null, partialRead);
+        super(CardType.ISO7816, tagId, scannedAt, partialRead);
         mApplications = apps;
     }
 


### PR DESCRIPTION
It's filled only through deserialization and never directly