### PR TITLE
Move getSerial from Calypso to Opus

### DIFF
--- a/src/main/java/au/id/micolous/metrodroid/transit/en1545/Calypso1545TransitData.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/en1545/Calypso1545TransitData.java
@@ -42,10 +42,6 @@ public abstract class Calypso1545TransitData extends En1545TransitData {
     private final String mSerial;
     private final List<TransitBalance> mBalances;
 
-    protected Calypso1545TransitData(CalypsoApplication card, En1545Container ticketEnvHolderFields, En1545Field contractListFields) {
-        this(card, ticketEnvHolderFields, contractListFields, getSerial(card));
-    }
-
     protected Calypso1545TransitData(CalypsoApplication card, En1545Container ticketEnvHolderFields, En1545Field contractListFields, String serial) {
         mSerial = serial;
         byte ticketEnv[] = {};
@@ -195,30 +191,6 @@ public abstract class Calypso1545TransitData extends En1545TransitData {
     }
 
     protected abstract En1545Transaction createTrip(byte[] data);
-
-    protected static String getSerial(CalypsoApplication card) {
-        ISO7816File iccFile = card.getFile(CalypsoApplication.File.ICC);
-        if (iccFile == null) {
-            return null;
-        }
-
-        ISO7816Record iccRecord = iccFile.getRecord(1);
-
-        if (iccRecord == null) {
-            return null;
-        }
-        byte[] data = iccRecord.getData();
-
-        if (Utils.byteArrayToLong(data, 16, 4) != 0) {
-            return Long.toString(Utils.byteArrayToLong(data, 16, 4));
-        }
-
-        if (Utils.byteArrayToLong(data, 0, 4) != 0) {
-            return Long.toString(Utils.byteArrayToLong(data, 0, 4));
-        }
-
-        return null;
-    }
 
     @Nullable
     @Override

--- a/src/main/java/au/id/micolous/metrodroid/transit/opus/OpusTransitData.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/opus/OpusTransitData.java
@@ -30,6 +30,7 @@ import au.id.micolous.farebot.R;
 import au.id.micolous.metrodroid.card.CardType;
 import au.id.micolous.metrodroid.card.calypso.CalypsoApplication;
 import au.id.micolous.metrodroid.card.calypso.CalypsoCardTransitFactory;
+import au.id.micolous.metrodroid.card.iso7816.ISO7816File;
 import au.id.micolous.metrodroid.card.iso7816.ISO7816Record;
 import au.id.micolous.metrodroid.transit.CardInfo;
 import au.id.micolous.metrodroid.transit.TransitIdentity;
@@ -94,7 +95,7 @@ public class OpusTransitData extends Calypso1545TransitData {
     );
 
     private OpusTransitData(CalypsoApplication card) {
-        super(card, ticketEnvFields, contractListFields);
+        super(card, ticketEnvFields, contractListFields, getSerial(card));
     }
 
     @Override
@@ -161,5 +162,29 @@ public class OpusTransitData extends Calypso1545TransitData {
 
     private OpusTransitData(Parcel parcel) {
         super(parcel);
+    }
+
+    private static String getSerial(CalypsoApplication card) {
+        ISO7816File iccFile = card.getFile(CalypsoApplication.File.ICC);
+        if (iccFile == null) {
+            return null;
+        }
+
+        ISO7816Record iccRecord = iccFile.getRecord(1);
+
+        if (iccRecord == null) {
+            return null;
+        }
+        byte[] data = iccRecord.getData();
+
+        if (Utils.byteArrayToLong(data, 16, 4) != 0) {
+            return Long.toString(Utils.byteArrayToLong(data, 16, 4));
+        }
+
+        if (Utils.byteArrayToLong(data, 0, 4) != 0) {
+            return Long.toString(Utils.byteArrayToLong(data, 0, 4));
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
This getSerial function is used only by Opus, so just move it there.