### PR TITLE
classic,ultralight: Catch Unauthorized and out-of-bounds exception in…

### DIFF
--- a/src/main/java/au/id/micolous/metrodroid/transit/charlie/CharlieCardTransitData.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/charlie/CharlieCardTransitData.java
@@ -36,7 +36,6 @@ import java.util.TimeZone;
 
 import au.id.micolous.farebot.R;
 import au.id.micolous.metrodroid.card.CardType;
-import au.id.micolous.metrodroid.card.UnauthorizedException;
 import au.id.micolous.metrodroid.card.classic.ClassicBlock;
 import au.id.micolous.metrodroid.card.classic.ClassicCard;
 import au.id.micolous.metrodroid.card.classic.ClassicCardTransitFactory;
@@ -204,25 +203,20 @@ public class CharlieCardTransitData extends TransitData {
     public static final ClassicCardTransitFactory FACTORY = new ClassicCardTransitFactory() {
         @Override
         public boolean earlyCheck(@NonNull List<ClassicSector> sectors) {
-            try {
-                ClassicSector sector0 = sectors.get(0);
-                byte[] b = sector0.getBlock(1).getData();
-                if (!Arrays.equals(Utils.byteArraySlice(b, 2, 14), new byte[] {
-                        0x04, 0x10, 0x04, 0x10, 0x04, 0x10,
-                        0x04, 0x10, 0x04, 0x10, 0x04, 0x10, 0x04, 0x10
-                }))
-                    return false;
-                ClassicSector sector1 = sectors.get(1);
-                if (sector1 instanceof UnauthorizedClassicSector)
-                    return true;
-                b = sector1.getBlock(0).getData();
-                return Arrays.equals(Utils.byteArraySlice(b, 0, 6), new byte[]{
-                        0x04, 0x10, 0x23, 0x45, 0x66, 0x77
-                });
-            } catch (IndexOutOfBoundsException | UnauthorizedException ignored) {
-                // If that sector number is too high, then it's not for us.
-            }
-            return false;
+            ClassicSector sector0 = sectors.get(0);
+            byte[] b = sector0.getBlock(1).getData();
+            if (!Arrays.equals(Utils.byteArraySlice(b, 2, 14), new byte[]{
+                    0x04, 0x10, 0x04, 0x10, 0x04, 0x10,
+                    0x04, 0x10, 0x04, 0x10, 0x04, 0x10, 0x04, 0x10
+            }))
+                return false;
+            ClassicSector sector1 = sectors.get(1);
+            if (sector1 instanceof UnauthorizedClassicSector)
+                return true;
+            b = sector1.getBlock(0).getData();
+            return Arrays.equals(Utils.byteArraySlice(b, 0, 6), new byte[]{
+                    0x04, 0x10, 0x23, 0x45, 0x66, 0x77
+            });
         }
 
         @Override

--- a/src/main/java/au/id/micolous/metrodroid/transit/clipper/ClipperUltralightTransitData.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/clipper/ClipperUltralightTransitData.java
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.List;
 
 import au.id.micolous.farebot.R;
-import au.id.micolous.metrodroid.card.UnauthorizedException;
 import au.id.micolous.metrodroid.card.ultralight.UltralightCard;
 import au.id.micolous.metrodroid.card.ultralight.UltralightCardTransitFactory;
 import au.id.micolous.metrodroid.transit.CardInfo;
@@ -60,13 +59,7 @@ public class ClipperUltralightTransitData extends TransitData {
     public final static UltralightCardTransitFactory FACTORY = new UltralightCardTransitFactory() {
         @Override
         public boolean check(@NonNull UltralightCard card) {
-            try {
-                byte[] head = card.getPage(4).getData();
-                return head[0] == 0x13;
-            } catch (IndexOutOfBoundsException | UnauthorizedException ignored) {
-                // If that sector number is too high, then it's not for us.
-                return false;
-            }
+            return card.getPage(4).getData()[0] == 0x13;
         }
 
         @Override

--- a/src/main/java/au/id/micolous/metrodroid/transit/easycard/EasyCardTransitData.kt
+++ b/src/main/java/au/id/micolous/metrodroid/transit/easycard/EasyCardTransitData.kt
@@ -85,15 +85,9 @@ data class EasyCardTransitData internal constructor(
         }
 
         val FACTORY = object : ClassicCardTransitFactory {
-            override fun earlyCheck(sectors: List<ClassicSector>): Boolean {
-                val data: ByteArray? = try {
-                    sectors[0][1].data
-                } catch (e: Exception) {
-                    null
-                }
-
-                return data != null && Arrays.equals(data, MAGIC)
-            }
+            override fun earlyCheck(sectors: List<ClassicSector>) = sectors[0][1].data?.let {
+                Arrays.equals(it, MAGIC)
+            } ?: false
 
             override fun earlySectors() = 1
 

--- a/src/main/java/au/id/micolous/metrodroid/transit/erg/ErgTransitData.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/erg/ErgTransitData.java
@@ -168,18 +168,7 @@ public class ErgTransitData extends TransitData {
          */
         @Override
         public boolean earlyCheck(@NonNull List<ClassicSector> sectors) {
-            byte[] file1;
-
-            try {
-                file1 = sectors.get(0).getBlock(1).getData();
-            } catch (UnauthorizedException ignored) {
-                // These blocks of the card are not protected.
-                // This must not be a ERG smartcard.
-                return false;
-            } catch (IndexOutOfBoundsException ignored) {
-                // If that's too high for us, then this isn't an ERG smartcard.
-                return false;
-            }
+            byte[] file1 = sectors.get(0).getBlock(1).getData();
 
             // Check for signature
             if (!Arrays.equals(Arrays.copyOfRange(file1, 0, SIGNATURE.length), SIGNATURE)) {

--- a/src/main/java/au/id/micolous/metrodroid/transit/kiev/KievTransitData.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/kiev/KievTransitData.java
@@ -28,7 +28,6 @@ import java.util.List;
 
 import au.id.micolous.farebot.R;
 import au.id.micolous.metrodroid.card.CardType;
-import au.id.micolous.metrodroid.card.UnauthorizedException;
 import au.id.micolous.metrodroid.card.classic.ClassicBlock;
 import au.id.micolous.metrodroid.card.classic.ClassicCard;
 import au.id.micolous.metrodroid.card.classic.ClassicCardTransitFactory;
@@ -115,13 +114,8 @@ public class KievTransitData extends TransitData {
 
         @Override
         public boolean earlyCheck(@NonNull List<ClassicSector> sectors) {
-            try {
-                return Utils.checkKeyHash(sectors.get(1).getKey(), "kiev",
-                        "902a69a9d68afa1ddac7b61a512f7d4f") >= 0;
-            } catch (IndexOutOfBoundsException | UnauthorizedException ignored) {
-                // If that sector number is too high, then it's not for us.
-            }
-            return false;
+            return Utils.checkKeyHash(sectors.get(1).getKey(), "kiev",
+                    "902a69a9d68afa1ddac7b61a512f7d4f") >= 0;
         }
 
         @Override

--- a/src/main/java/au/id/micolous/metrodroid/transit/lax_tap/LaxTapTransitData.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/lax_tap/LaxTapTransitData.java
@@ -26,7 +26,6 @@ import android.support.annotation.VisibleForTesting;
 
 import au.id.micolous.farebot.R;
 import au.id.micolous.metrodroid.card.CardType;
-import au.id.micolous.metrodroid.card.UnauthorizedException;
 import au.id.micolous.metrodroid.card.classic.ClassicCard;
 import au.id.micolous.metrodroid.card.classic.ClassicCardTransitFactory;
 import au.id.micolous.metrodroid.card.classic.ClassicSector;
@@ -100,22 +99,14 @@ public class LaxTapTransitData extends NextfareTransitData {
 
         @Override
         public boolean earlyCheck(@NonNull List<ClassicSector> sectors) {
-            try {
-                ClassicSector sector0 = sectors.get(0);
-                byte[] block1 = sector0.getBlock(1).getData();
-                if (!Arrays.equals(Arrays.copyOfRange(block1, 1, 15), BLOCK1)) {
-                    return false;
-                }
-
-                byte[] block2 = sector0.getBlock(2).getData();
-                return Arrays.equals(Arrays.copyOfRange(block2, 0, 4), BLOCK2);
-            } catch (UnauthorizedException ex) {
-                // It is not possible to identify the card without a key
-                return false;
-            } catch (IndexOutOfBoundsException ignored) {
-                // If the sector/block number is too high, it's not for us
+            ClassicSector sector0 = sectors.get(0);
+            byte[] block1 = sector0.getBlock(1).getData();
+            if (!Arrays.equals(Arrays.copyOfRange(block1, 1, 15), BLOCK1)) {
                 return false;
             }
+
+            byte[] block2 = sector0.getBlock(2).getData();
+            return Arrays.equals(Arrays.copyOfRange(block2, 0, 4), BLOCK2);
         }
 
         @Override

--- a/src/main/java/au/id/micolous/metrodroid/transit/metroq/MetroQTransitData.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/metroq/MetroQTransitData.java
@@ -34,7 +34,6 @@ import java.util.TimeZone;
 
 import au.id.micolous.farebot.R;
 import au.id.micolous.metrodroid.card.CardType;
-import au.id.micolous.metrodroid.card.UnauthorizedException;
 import au.id.micolous.metrodroid.card.classic.ClassicBlock;
 import au.id.micolous.metrodroid.card.classic.ClassicCard;
 import au.id.micolous.metrodroid.card.classic.ClassicCardTransitFactory;
@@ -103,23 +102,15 @@ public class MetroQTransitData extends TransitData {
     public static final ClassicCardTransitFactory FACTORY = new ClassicCardTransitFactory() {
         @Override
         public boolean earlyCheck(@NonNull List<ClassicSector> sectors) {
-            try {
-                ClassicSector sector = sectors.get(0);
-                for (int i = 1; i < 3; i++) {
-                    byte[] block = sector.getBlock(i).getData();
-                    for (int j = (i == 1 ? 1 : 0); j < 8; j++)
-                        if (Utils.byteArrayToInt(block, j * 2, 2) != METRO_Q_ID
-                                && (i != 2 || j != 6))
-                            return false;
-                }
-                return true;
-            } catch (UnauthorizedException ex) {
-                // Not ours
-                return false;
-            } catch (IndexOutOfBoundsException ignored) {
-                // If the sector/block number is too high, it's not for us
-                return false;
+            ClassicSector sector = sectors.get(0);
+            for (int i = 1; i < 3; i++) {
+                byte[] block = sector.getBlock(i).getData();
+                for (int j = (i == 1 ? 1 : 0); j < 8; j++)
+                    if (Utils.byteArrayToInt(block, j * 2, 2) != METRO_Q_ID
+                            && (i != 2 || j != 6))
+                        return false;
             }
+            return true;
         }
 
         @Override

--- a/src/main/java/au/id/micolous/metrodroid/transit/msp_goto/MspGotoTransitData.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/msp_goto/MspGotoTransitData.java
@@ -11,7 +11,6 @@ import java.util.TimeZone;
 
 import au.id.micolous.farebot.R;
 import au.id.micolous.metrodroid.card.CardType;
-import au.id.micolous.metrodroid.card.UnauthorizedException;
 import au.id.micolous.metrodroid.card.classic.ClassicCard;
 import au.id.micolous.metrodroid.card.classic.ClassicCardTransitFactory;
 import au.id.micolous.metrodroid.card.classic.ClassicSector;
@@ -75,22 +74,14 @@ public class MspGotoTransitData extends NextfareTransitData {
 
         @Override
         public boolean earlyCheck(@NonNull List<ClassicSector> sectors) {
-            try {
-                ClassicSector sector0 = sectors.get(0);
-                byte[] block1 = sector0.getBlock(1).getData();
-                if (!Arrays.equals(Arrays.copyOfRange(block1, 1, 15), BLOCK1)) {
-                    return false;
-                }
-
-                byte[] block2 = sector0.getBlock(2).getData();
-                return Arrays.equals(block2, BLOCK2);
-            } catch (UnauthorizedException ex) {
-                // It is not possible to identify the card without a key
-                return false;
-            } catch (IndexOutOfBoundsException ignored) {
-                // If the sector/block number is too high, it's not for us
+            ClassicSector sector0 = sectors.get(0);
+            byte[] block1 = sector0.getBlock(1).getData();
+            if (!Arrays.equals(Arrays.copyOfRange(block1, 1, 15), BLOCK1)) {
                 return false;
             }
+
+            byte[] block2 = sector0.getBlock(2).getData();
+            return Arrays.equals(block2, BLOCK2);
         }
 
         @Override

--- a/src/main/java/au/id/micolous/metrodroid/transit/nextfare/NextfareTransitData.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/nextfare/NextfareTransitData.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.TimeZone;
 
 import au.id.micolous.farebot.R;
-import au.id.micolous.metrodroid.card.UnauthorizedException;
 import au.id.micolous.metrodroid.card.classic.ClassicBlock;
 import au.id.micolous.metrodroid.card.classic.ClassicCard;
 import au.id.micolous.metrodroid.card.classic.ClassicCardTransitFactory;
@@ -272,16 +271,8 @@ public class NextfareTransitData extends TransitData {
     protected static class NextFareTransitFactory implements ClassicCardTransitFactory {
         @Override
         public boolean earlyCheck(@NonNull List<ClassicSector> sectors) {
-            try {
-                byte[] blockData = sectors.get(0).getBlock(1).getData();
-                return Arrays.equals(Arrays.copyOfRange(blockData, 1, 9), MANUFACTURER);
-            } catch (UnauthorizedException ex) {
-                // It is not possible to identify the card without a key
-                return false;
-            } catch (IndexOutOfBoundsException ignored) {
-                // If the sector/block number is too high, it's not for us
-                return false;
-            }
+            byte[] blockData = sectors.get(0).getBlock(1).getData();
+            return Arrays.equals(Arrays.copyOfRange(blockData, 1, 9), MANUFACTURER);
         }
 
         @Override

--- a/src/main/java/au/id/micolous/metrodroid/transit/nextfare/ultralight/NextfareUnknownUltralightTransitData.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/nextfare/ultralight/NextfareUnknownUltralightTransitData.java
@@ -24,7 +24,6 @@ import android.support.annotation.NonNull;
 
 import java.util.TimeZone;
 
-import au.id.micolous.metrodroid.card.UnauthorizedException;
 import au.id.micolous.metrodroid.card.ultralight.UltralightCard;
 import au.id.micolous.metrodroid.card.ultralight.UltralightCardTransitFactory;
 import au.id.micolous.metrodroid.transit.TransitCurrency;
@@ -51,13 +50,8 @@ public class NextfareUnknownUltralightTransitData extends NextfareUltralightTran
     public final static UltralightCardTransitFactory FACTORY = new UltralightCardTransitFactory() {
         @Override
         public boolean check(@NonNull UltralightCard card) {
-            try {
-                int head = Utils.byteArrayToInt(card.getPage(4).getData(), 0, 3);
-                return head == 0x0a0400 || head == 0x0a0800;
-            } catch (IndexOutOfBoundsException | UnauthorizedException ignored) {
-                // If that sector number is too high, then it's not for us.
-                return false;
-            }
+            int head = Utils.byteArrayToInt(card.getPage(4).getData(), 0, 3);
+            return head == 0x0a0400 || head == 0x0a0800;
         }
 
         @Override

--- a/src/main/java/au/id/micolous/metrodroid/transit/ovc/OVChipTransitData.kt
+++ b/src/main/java/au/id/micolous/metrodroid/transit/ovc/OVChipTransitData.kt
@@ -201,14 +201,9 @@ data class OVChipTransitData(
 
         val FACTORY: ClassicCardTransitFactory = object : ClassicCardTransitFactory {
             override fun earlyCheck(sectors: List<ClassicSector>): Boolean {
-                val sector = sectors[0]
-
-                if (sector is UnauthorizedClassicSector || sector is InvalidClassicSector)
-                    return false
-
                 // Starting at 0×010, 8400 0000 0603 a000 13ae e401 xxxx 0e80 80e8 seems to exist on all OVC's (with xxxx different).
                 // http://www.ov-chipkaart.de/back-up/3-8-11/www.ov-chipkaart.me/blog/index7e09.html?page_id=132
-                val blockData = sector.readBlocks(1, 1)
+                val blockData = sectors[0].readBlocks(1, 1)
                 return Arrays.equals(blockData.copyOfRange(0, 11), OVC_HEADER)
             }
 

--- a/src/main/java/au/id/micolous/metrodroid/transit/ovc/OvcUltralightTransitData.kt
+++ b/src/main/java/au/id/micolous/metrodroid/transit/ovc/OvcUltralightTransitData.kt
@@ -18,7 +18,6 @@
  */
 package au.id.micolous.metrodroid.transit.ovc
 
-import au.id.micolous.metrodroid.card.UnauthorizedException
 import au.id.micolous.metrodroid.card.ultralight.UltralightCard
 import au.id.micolous.metrodroid.card.ultralight.UltralightCardTransitFactory
 import au.id.micolous.metrodroid.transit.TransactionTrip
@@ -48,15 +47,9 @@ private fun parse(card: UltralightCard): OvcUltralightTransitData {
 class OvcUltralightTransitFactory : UltralightCardTransitFactory {
     // getAllCards not implemented -- Classic already adds it to supported cards
 
-    override fun check(card: UltralightCard) = try {
-        val head = card.getPage(4).data
-        // FIXME: check with more samples
-        head[0] == 0xc0.toByte() || head[0] == 0xc8.toByte()
-    } catch (ignored: IndexOutOfBoundsException) {
-        false
-    } catch (ignored: UnauthorizedException) {
-        false
-    }
+    // FIXME: check with more samples
+    override fun check(card: UltralightCard) =
+        card.getPage(4).data[0] in listOf(0xc0.toByte(), 0xc8.toByte())
 
     override fun parseTransitData(ultralightCard: UltralightCard) = parse(ultralightCard)
 

--- a/src/main/java/au/id/micolous/metrodroid/transit/podorozhnik/PodorozhnikTransitData.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/podorozhnik/PodorozhnikTransitData.java
@@ -264,15 +264,10 @@ public class PodorozhnikTransitData extends TransitData {
     public static final ClassicCardTransitFactory FACTORY = new ClassicCardTransitFactory() {
         @Override
         public boolean earlyCheck(@NonNull List<ClassicSector> sectors) {
-            try {
-                ClassicSectorKey key = sectors.get(4).getKey();
+            ClassicSectorKey key = sectors.get(4).getKey();
 
-                Log.d(TAG, "Checking for Podorozhnik key...");
-                return Utils.checkKeyHash(key, KEY_SALT, KEY_DIGEST_A, KEY_DIGEST_B) >= 0;
-            } catch (IndexOutOfBoundsException ignored) {
-                // If that sector number is too high, then it's not for us.
-            }
-            return false;
+            Log.d(TAG, "Checking for Podorozhnik key...");
+            return Utils.checkKeyHash(key, KEY_SALT, KEY_DIGEST_A, KEY_DIGEST_B) >= 0;
         }
 
         @Override

--- a/src/main/java/au/id/micolous/metrodroid/transit/ricaricami/RicaricaMiTransitData.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/ricaricami/RicaricaMiTransitData.java
@@ -28,7 +28,6 @@ import java.util.List;
 
 import au.id.micolous.farebot.R;
 import au.id.micolous.metrodroid.card.CardType;
-import au.id.micolous.metrodroid.card.UnauthorizedException;
 import au.id.micolous.metrodroid.card.classic.ClassicCard;
 import au.id.micolous.metrodroid.card.classic.ClassicCardTransitFactory;
 import au.id.micolous.metrodroid.card.classic.ClassicSector;
@@ -194,21 +193,13 @@ public class RicaricaMiTransitData extends En1545TransitData {
     public static final ClassicCardTransitFactory FACTORY = new ClassicCardTransitFactory() {
         @Override
         public boolean earlyCheck(@NonNull List<ClassicSector> sectors) {
-            try {
-                for (int i = 1; i < 3; i++) {
-                    byte[] block = sectors.get(0).getBlock(i).getData();
-                    for (int j = (i == 1 ? 1 : 0); j < 8; j++)
-                        if (Utils.byteArrayToInt(block, j * 2, 2) != RICARICA_MI_ID)
-                            return false;
-                }
-                return true;
-            } catch (UnauthorizedException ex) {
-                // Not ours
-                return false;
-            } catch (IndexOutOfBoundsException ignored) {
-                // If the sector/block number is too high, it's not for us
-                return false;
+            for (int i = 1; i < 3; i++) {
+                byte[] block = sectors.get(0).getBlock(i).getData();
+                for (int j = (i == 1 ? 1 : 0); j < 8; j++)
+                    if (Utils.byteArrayToInt(block, j * 2, 2) != RICARICA_MI_ID)
+                        return false;
             }
+            return true;
         }
 
         @Override

--- a/src/main/java/au/id/micolous/metrodroid/transit/rkf/RkfTransitData.kt
+++ b/src/main/java/au/id/micolous/metrodroid/transit/rkf/RkfTransitData.kt
@@ -125,19 +125,15 @@ data class RkfTransitData internal constructor(
         )
 
         val FACTORY = object : ClassicCardTransitFactory {
-            override fun earlyCardInfo(sectors: MutableList<ClassicSector>) = issuerMap[getIssuer(sectors[0])]
+            override fun earlyCardInfo(sectors: List<ClassicSector>) = issuerMap[getIssuer(sectors[0])]
 
-            override fun earlyCheck(sectors: MutableList<ClassicSector>) = try {
-                Utils.checkKeyHash(sectors[0].key, "rkf",
-                        // Most cards
-                        "b9ae9b2f6855aa199b4af7bdc130ba1c",
-                        "2107bb612627fb1dfe57348fea8a8b58",
-                        // Jo-jo
-                        "f40bb9394d94c7040c1dd19997b4f5e8") >= 0
-            } catch (ignored: IndexOutOfBoundsException) {
-                // If that sector number is too high, then it's not for us.
-                false
-            }
+            override fun earlyCheck(sectors: List<ClassicSector>) =
+                    Utils.checkKeyHash(sectors[0].key, "rkf",
+                            // Most cards
+                            "b9ae9b2f6855aa199b4af7bdc130ba1c",
+                            "2107bb612627fb1dfe57348fea8a8b58",
+                            // Jo-jo
+                            "f40bb9394d94c7040c1dd19997b4f5e8") >= 0
 
             override fun earlySectors() = 1
 

--- a/src/main/java/au/id/micolous/metrodroid/transit/seq_go/SeqGoTransitData.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/seq_go/SeqGoTransitData.java
@@ -26,7 +26,6 @@ import android.support.annotation.VisibleForTesting;
 
 import au.id.micolous.farebot.R;
 import au.id.micolous.metrodroid.card.CardType;
-import au.id.micolous.metrodroid.card.UnauthorizedException;
 import au.id.micolous.metrodroid.card.classic.ClassicCard;
 import au.id.micolous.metrodroid.card.classic.ClassicCardTransitFactory;
 import au.id.micolous.metrodroid.card.classic.ClassicSector;
@@ -109,23 +108,15 @@ public class SeqGoTransitData extends NextfareTransitData {
 
         @Override
         public boolean earlyCheck(@NonNull List<ClassicSector> sectors) {
-            try {
-                ClassicSector sector0 = sectors.get(0);
-                byte[] blockData = sector0.getBlock(1).getData();
-                if (!Arrays.equals(Arrays.copyOfRange(blockData, 1, 9), MANUFACTURER)) {
-                    return false;
-                }
-
-                byte[] systemCode = Arrays.copyOfRange(blockData, 9, 15);
-                //Log.d(TAG, "SystemCode = " + Utils.getHexString(systemCode));
-                return Arrays.equals(systemCode, SYSTEM_CODE1) || Arrays.equals(systemCode, SYSTEM_CODE2);
-            } catch (UnauthorizedException ex) {
-                // It is not possible to identify the card without a key
-                return false;
-            } catch (IndexOutOfBoundsException ignored) {
-                // If the sector/block number is too high, it's not for us
+            ClassicSector sector0 = sectors.get(0);
+            byte[] blockData = sector0.getBlock(1).getData();
+            if (!Arrays.equals(Arrays.copyOfRange(blockData, 1, 9), MANUFACTURER)) {
                 return false;
             }
+
+            byte[] systemCode = Arrays.copyOfRange(blockData, 9, 15);
+            //Log.d(TAG, "SystemCode = " + Utils.getHexString(systemCode));
+            return Arrays.equals(systemCode, SYSTEM_CODE1) || Arrays.equals(systemCode, SYSTEM_CODE2);
         }
 
         @Override

--- a/src/main/java/au/id/micolous/metrodroid/transit/serialonly/StrelkaTransitData.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/serialonly/StrelkaTransitData.java
@@ -121,18 +121,12 @@ public class StrelkaTransitData extends SerialOnlyTransitData {
 
         @Override
         public boolean earlyCheck(@NonNull List<ClassicSector> sectors) {
-            try {
-                byte[] toc = sectors.get(0).getBlock(2).getData();
-                // Check toc entries for sectors 10,12,13,14 and 15
-                return Utils.byteArrayToInt(toc, 4, 2) == 0x18f0
-                        && Utils.byteArrayToInt(toc, 8, 2) == 5
-                        && Utils.byteArrayToInt(toc, 10, 2) == 0x18e0
-                        && Utils.byteArrayToInt(toc, 12, 2) == 0x18e8;
-            } catch (IndexOutOfBoundsException | UnauthorizedException ignored) {
-                // If that sector number is too high, then it's not for us.
-                // If we can't read we can't do anything
-            }
-            return false;
+            byte[] toc = sectors.get(0).getBlock(2).getData();
+            // Check toc entries for sectors 10,12,13,14 and 15
+            return Utils.byteArrayToInt(toc, 4, 2) == 0x18f0
+                    && Utils.byteArrayToInt(toc, 8, 2) == 5
+                    && Utils.byteArrayToInt(toc, 10, 2) == 0x18e0
+                    && Utils.byteArrayToInt(toc, 12, 2) == 0x18e8;
         }
 
         @Override

--- a/src/main/java/au/id/micolous/metrodroid/transit/serialonly/SunCardTransitData.kt
+++ b/src/main/java/au/id/micolous/metrodroid/transit/serialonly/SunCardTransitData.kt
@@ -21,7 +21,6 @@ package au.id.micolous.metrodroid.transit.serialonly
 
 import au.id.micolous.farebot.R
 import au.id.micolous.metrodroid.card.CardType
-import au.id.micolous.metrodroid.card.UnauthorizedException
 import au.id.micolous.metrodroid.card.classic.ClassicCard
 import au.id.micolous.metrodroid.card.classic.ClassicCardTransitFactory
 import au.id.micolous.metrodroid.card.classic.ClassicSector
@@ -76,17 +75,10 @@ data class SunCardTransitData(private val mSerial: Int = 0) : SerialOnlyTransitD
 
             override fun parseTransitData(classicCard: ClassicCard) = SunCardTransitData(classicCard)
 
-            override fun earlyCheck(sectors: List<ClassicSector>) = try {
+            override fun earlyCheck(sectors: List<ClassicSector>) =
                 // I hope it is magic as other than zeros, ff's and serial there is nothing
                 // on the card
                 Utils.byteArrayToInt(sectors[0][1].data, 7, 4) == 0x070515ff
-            } catch (ignored: IndexOutOfBoundsException) {
-                // If that sector number is too high, then it's not for us.
-                // If we can't read we can't do anything
-                false
-            } catch (ignored: UnauthorizedException) {
-                false
-            }
 
             override fun earlySectors() = 1
 

--- a/src/main/java/au/id/micolous/metrodroid/transit/serialonly/TartuTransitFactory.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/serialonly/TartuTransitFactory.java
@@ -69,23 +69,18 @@ public class TartuTransitFactory implements ClassicCardTransitFactory {
 
     @Override
     public boolean earlyCheck(@NonNull List<ClassicSector> sectors) {
-        try {
-            ClassicSector sector0 = sectors.get(0);
-            byte[] b = sector0.getBlock(1).getData();
-            if (Utils.byteArrayToInt(b, 2, 4) != 0x03e103e1)
-                return false;
-            ClassicSector sector1 = sectors.get(1);
-            b = sector1.getBlock(0).getData();
-            if (!Arrays.equals(Utils.byteArraySlice(b, 7, 9), Utils.stringToByteArray("pilet.ee:")))
-                return false;
-            b = sector1.getBlock(1).getData();
-            if (!Arrays.equals(Utils.byteArraySlice(b, 0, 6), Utils.stringToByteArray("ekaart")))
-                return false;
-            return true;
-        } catch (IndexOutOfBoundsException | UnauthorizedException ignored) {
-            // If that sector number is too high, then it's not for us.
-        }
-        return false;
+        ClassicSector sector0 = sectors.get(0);
+        byte[] b = sector0.getBlock(1).getData();
+        if (Utils.byteArrayToInt(b, 2, 4) != 0x03e103e1)
+            return false;
+        ClassicSector sector1 = sectors.get(1);
+        b = sector1.getBlock(0).getData();
+        if (!Arrays.equals(Utils.byteArraySlice(b, 7, 9), Utils.stringToByteArray("pilet.ee:")))
+            return false;
+        b = sector1.getBlock(1).getData();
+        if (!Arrays.equals(Utils.byteArraySlice(b, 0, 6), Utils.stringToByteArray("ekaart")))
+            return false;
+        return true;
     }
 
     @Override

--- a/src/main/java/au/id/micolous/metrodroid/transit/troika/TroikaHybridTransitData.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/troika/TroikaHybridTransitData.java
@@ -24,7 +24,6 @@ import android.os.Parcelable;
 import android.support.annotation.NonNull;
 
 import au.id.micolous.farebot.R;
-import au.id.micolous.metrodroid.card.UnauthorizedException;
 import au.id.micolous.metrodroid.card.classic.ClassicCard;
 import au.id.micolous.metrodroid.card.classic.ClassicCardTransitFactory;
 import au.id.micolous.metrodroid.card.classic.ClassicSector;
@@ -170,13 +169,7 @@ public class TroikaHybridTransitData extends TransitData {
 
         @Override
         public boolean check(@NonNull ClassicCard card) {
-            try {
-                return TroikaBlock.check(card.getSector(8).getBlock(0).getData());
-            } catch (IndexOutOfBoundsException|UnauthorizedException ignored) {
-                // If that sector number is too high, then it's not for us.
-                // If we can't read we can't do anything
-            }
-            return false;
+            return TroikaBlock.check(card.getSector(8).getBlock(0).getData());
         }
 
         @Override

--- a/src/main/java/au/id/micolous/metrodroid/transit/troika/TroikaUltralightTransitData.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/troika/TroikaUltralightTransitData.java
@@ -26,7 +26,6 @@ import android.support.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 
-import au.id.micolous.metrodroid.card.UnauthorizedException;
 import au.id.micolous.metrodroid.card.ultralight.UltralightCard;
 import au.id.micolous.metrodroid.card.ultralight.UltralightCardTransitFactory;
 import au.id.micolous.metrodroid.transit.CardInfo;
@@ -55,12 +54,7 @@ public class TroikaUltralightTransitData extends TransitData {
     public final static UltralightCardTransitFactory FACTORY = new UltralightCardTransitFactory() {
         @Override
         public boolean check(@NonNull UltralightCard card) {
-            try {
-                return TroikaBlock.check(card.getPage(4).getData());
-            } catch (IndexOutOfBoundsException | UnauthorizedException ignored) {
-                // If that sector number is too high, then it's not for us.
-                return false;
-            }
+            return TroikaBlock.check(card.getPage(4).getData());
         }
 
         @Override

--- a/src/main/java/au/id/micolous/metrodroid/transit/ventra/VentraUltralightTransitData.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/ventra/VentraUltralightTransitData.java
@@ -28,7 +28,6 @@ import java.util.TimeZone;
 
 import au.id.micolous.farebot.R;
 import au.id.micolous.metrodroid.card.CardType;
-import au.id.micolous.metrodroid.card.UnauthorizedException;
 import au.id.micolous.metrodroid.card.ultralight.UltralightCard;
 import au.id.micolous.metrodroid.card.ultralight.UltralightCardTransitFactory;
 import au.id.micolous.metrodroid.transit.CardInfo;
@@ -71,19 +70,14 @@ public class VentraUltralightTransitData extends NextfareUltralightTransitData {
 
         @Override
         public boolean check(@NonNull UltralightCard card) {
-            try {
-                int head = Utils.byteArrayToInt(card.getPage(4).getData(), 0, 3);
-                if (head != 0x0a0400 && head != 0x0a0800)
-                    return false;
-                byte[] page1 = card.getPage(5).getData();
-                if (page1[1] != 1 || ((page1[2] & 0x80) == 0x80) || page1[3] != 0)
-                    return false;
-                byte[] page2 = card.getPage(6).getData();
-                return Utils.byteArrayToInt(page2, 0, 3) == 0;
-            } catch (IndexOutOfBoundsException | UnauthorizedException ignored) {
-                // If that sector number is too high, then it's not for us.
+            int head = Utils.byteArrayToInt(card.getPage(4).getData(), 0, 3);
+            if (head != 0x0a0400 && head != 0x0a0800)
                 return false;
-            }
+            byte[] page1 = card.getPage(5).getData();
+            if (page1[1] != 1 || ((page1[2] & 0x80) == 0x80) || page1[3] != 0)
+                return false;
+            byte[] page2 = card.getPage(6).getData();
+            return Utils.byteArrayToInt(page2, 0, 3) == 0;
         }
 
         @Override

--- a/src/main/java/au/id/micolous/metrodroid/transit/yvr_compass/CompassUltralightTransitData.java
+++ b/src/main/java/au/id/micolous/metrodroid/transit/yvr_compass/CompassUltralightTransitData.java
@@ -29,7 +29,6 @@ import java.util.TimeZone;
 
 import au.id.micolous.farebot.R;
 import au.id.micolous.metrodroid.card.CardType;
-import au.id.micolous.metrodroid.card.UnauthorizedException;
 import au.id.micolous.metrodroid.card.ultralight.UltralightCard;
 import au.id.micolous.metrodroid.card.ultralight.UltralightCardTransitFactory;
 import au.id.micolous.metrodroid.transit.CardInfo;
@@ -74,19 +73,14 @@ public class CompassUltralightTransitData extends NextfareUltralightTransitData 
 
         @Override
         public boolean check(@NonNull UltralightCard card) {
-            try {
-                int head = Utils.byteArrayToInt(card.getPage(4).getData(), 0, 3);
-                if (head != 0x0a0400 && head != 0x0a0800)
-                    return false;
-                byte[] page1 = card.getPage(5).getData();
-                if (page1[1] != 1 || ((page1[2] & 0x80) != 0x80) || page1[3] != 0)
-                    return false;
-                byte[] page2 = card.getPage(6).getData();
-                return Utils.byteArrayToInt(page2, 0, 3) == 0;
-            } catch (IndexOutOfBoundsException | UnauthorizedException ignored) {
-                // If that sector number is too high, then it's not for us.
+            int head = Utils.byteArrayToInt(card.getPage(4).getData(), 0, 3);
+            if (head != 0x0a0400 && head != 0x0a0800)
                 return false;
-            }
+            byte[] page1 = card.getPage(5).getData();
+            if (page1[1] != 1 || ((page1[2] & 0x80) != 0x80) || page1[3] != 0)
+                return false;
+            byte[] page2 = card.getPage(6).getData();
+            return Utils.byteArrayToInt(page2, 0, 3) == 0;
         }
 
         @Override

--- a/src/main/java/au/id/micolous/metrodroid/transit/zolotayakorona/ZolotayaKoronaTransitData.kt
+++ b/src/main/java/au/id/micolous/metrodroid/transit/zolotayakorona/ZolotayaKoronaTransitData.kt
@@ -25,7 +25,6 @@ import java.util.TimeZone
 
 import au.id.micolous.farebot.R
 import au.id.micolous.metrodroid.card.CardType
-import au.id.micolous.metrodroid.card.UnauthorizedException
 import au.id.micolous.metrodroid.card.classic.ClassicCard
 import au.id.micolous.metrodroid.card.classic.ClassicCardTransitFactory
 import au.id.micolous.metrodroid.card.classic.ClassicSector
@@ -214,17 +213,10 @@ data class ZolotayaKoronaTransitData internal constructor(
             }
 
             override fun earlyCheck(sectors: List<ClassicSector>): Boolean {
-                try {
-                    val toc = sectors[0][1].data
-                    // Check toc entries for sectors 10,12,13,14 and 15
-                    return Utils.byteArrayToInt(toc, 8, 2) == 0x18ee && Utils.byteArrayToInt(toc, 12, 2) == 0x18ee
-                } catch (ignored: IndexOutOfBoundsException) {
-                    // If that sector number is too high, then it's not for us.
-                    // If we can't read we can't do anything
-                } catch (ignored: UnauthorizedException) {
-                }
-
-                return false
+                val toc = sectors[0][1].data
+                // Check toc entries for sectors 10,12,13,14 and 15
+                return Utils.byteArrayToInt(toc, 8, 2) == 0x18ee
+                        && Utils.byteArrayToInt(toc, 12, 2) == 0x18ee
             }
 
             override fun earlySectors() = 1


### PR DESCRIPTION
… caller

Every card transform those exceptions into false, so just do it in caller
and hence reduce the boilerplate.