### PR TITLE
Merge different paths of parsing EZ-link userData

### DIFF
--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/ezlink/EZLinkTrip.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/ezlink/EZLinkTrip.kt
@@ -31,6 +31,41 @@ import au.id.micolous.metrodroid.transit.Station
 import au.id.micolous.metrodroid.transit.TransitCurrency
 import au.id.micolous.metrodroid.transit.Trip
 
+data class EZUserData(val startStation: Station?,
+                      val endStation: Station?,
+                      val routeName: String) {
+    companion object {
+        fun parse(userData: String, type: CEPASTransaction.TransactionType): EZUserData {
+            if (type == CEPASTransaction.TransactionType.BUS && (
+                            userData.startsWith("SVC")
+                                    || userData.startsWith("BUS")))
+                return EZUserData(null, null,
+                        Localizer.localizeString(R.string.ez_bus_number, userData.substring(3, 7).replace(" ", "")))
+            if (type == CEPASTransaction.TransactionType.CREATION)
+                return EZUserData(Station.nameOnly(userData), null, Localizer.localizeString(R.string.ez_first_use))
+            if (type == CEPASTransaction.TransactionType.RETAIL)
+                return EZUserData(Station.nameOnly(userData), null, Localizer.localizeString(R.string.ez_retail_purchase))
+
+            val routeName = when (type) {
+                CEPASTransaction.TransactionType.BUS -> Localizer.localizeString(R.string.unknown_format, userData)
+                // FIXME: These aren't actually routes...
+                CEPASTransaction.TransactionType.BUS_REFUND -> Localizer.localizeString(R.string.ez_bus_refund)
+                CEPASTransaction.TransactionType.MRT -> Localizer.localizeString(R.string.ez_mrt)
+                CEPASTransaction.TransactionType.TOP_UP -> Localizer.localizeString(R.string.ez_topup)
+                CEPASTransaction.TransactionType.SERVICE -> Localizer.localizeString(R.string.ez_service_charge)
+                else -> Localizer.localizeString(R.string.unknown_format, type.toString())
+            }
+
+            if (userData.length > 6 && (userData[3] == '-' || userData[3] == ' ')) {
+                val startStationAbbr = userData.substring(0, 3)
+                val endStationAbbr = userData.substring(4, 7)
+                return EZUserData(EZLinkTransitData.getStation(startStationAbbr), EZLinkTransitData.getStation(endStationAbbr), routeName)
+            }
+            return EZUserData(Station.nameOnly(userData), null, routeName)
+        }
+    }
+}
+
 @Parcelize
 class EZLinkTrip (private val mTransaction: CEPASTransaction,
                   private val mCardName: String): Trip() {
@@ -39,7 +74,7 @@ class EZLinkTrip (private val mTransaction: CEPASTransaction,
         get() = mTransaction.timestamp
 
     override val routeName: String?
-        get() = getRouteName(mTransaction.type, mTransaction.userData)
+        get() = EZUserData.parse(mTransaction.userData, mTransaction.type).routeName
 
     override val humanReadableRouteID: String?
         get() = mTransaction.userData
@@ -48,31 +83,10 @@ class EZLinkTrip (private val mTransaction: CEPASTransaction,
         get() = if (mTransaction.type === CEPASTransaction.TransactionType.CREATION) null else TransitCurrency.SGD(-mTransaction.amount)
 
     override val startStation: Station?
-        get() {
-            if (mTransaction.type === CEPASTransaction.TransactionType.BUS && (
-                            mTransaction.userData.startsWith("SVC")
-                                    || mTransaction.userData.startsWith("BUS")))
-                return null
-            if (mTransaction.type === CEPASTransaction.TransactionType.CREATION)
-                return Station.nameOnly(mTransaction.userData)
-            if (mTransaction.userData[3] == '-' || mTransaction.userData[3] == ' ') {
-                val startStationAbbr = mTransaction.userData.substring(0, 3)
-                return EZLinkTransitData.getStation(startStationAbbr)
-            }
-            return Station.nameOnly(mTransaction.userData)
-        }
+        get() = EZUserData.parse(mTransaction.userData, mTransaction.type).startStation
 
     override val endStation: Station?
-        get() {
-            if (mTransaction.type === CEPASTransaction.TransactionType.CREATION)
-                return null
-            if (mTransaction.userData[3] == '-' || mTransaction.userData[3] == ' ') {
-                val endStationAbbr = mTransaction.userData.substring(4, 7)
-                return EZLinkTransitData.getStation(endStationAbbr)
-            }
-            return null
-        }
-
+        get() = EZUserData.parse(mTransaction.userData, mTransaction.type).endStation
 
     override val mode: Trip.Mode
         get() = getMode(mTransaction.type)
@@ -99,24 +113,6 @@ class EZLinkTrip (private val mTransaction: CEPASTransaction,
                     CEPASTransaction.TransactionType.SERVICE -> if (isShort && cardName == "EZ-Link") "EZ" else cardName
                     CEPASTransaction.TransactionType.RETAIL -> "POS"
                     else -> "SMRT"
-                }
-
-        fun getRouteName(type: CEPASTransaction.TransactionType, userData: String) =
-                when (type) {
-                    CEPASTransaction.TransactionType.BUS -> {
-                        if (userData.startsWith("SVC") || userData.startsWith("BUS"))
-                            Localizer.localizeString(R.string.ez_bus_number, userData.substring(3, 7).replace(" ", ""))
-                        else
-                            Localizer.localizeString(R.string.unknown_format, userData)
-                    }
-                    // FIXME: These aren't actually routes...
-                    CEPASTransaction.TransactionType.BUS_REFUND -> Localizer.localizeString(R.string.ez_bus_refund)
-                    CEPASTransaction.TransactionType.MRT -> Localizer.localizeString(R.string.ez_mrt)
-                    CEPASTransaction.TransactionType.TOP_UP -> Localizer.localizeString(R.string.ez_topup)
-                    CEPASTransaction.TransactionType.CREATION -> Localizer.localizeString(R.string.ez_first_use)
-                    CEPASTransaction.TransactionType.RETAIL -> Localizer.localizeString(R.string.ez_retail_purchase)
-                    CEPASTransaction.TransactionType.SERVICE -> Localizer.localizeString(R.string.ez_service_charge)
-                    else -> Localizer.localizeString(R.string.unknown_format, type.toString())
                 }
     }
 }


### PR DESCRIPTION
This created a lot of code duplication and it was overseen that strings like
"ABC DE" as POS seller would crash the parser