### PR TITLE
MifareClassic reader authentication fixes

### DIFF
--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/classic/ClassicAuthenticator.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/classic/ClassicAuthenticator.kt
@@ -45,7 +45,7 @@ class ClassicAuthenticator internal constructor(private val mKeys: ClassicKeys,
                        sectorKey: ClassicSectorKey): Boolean {
         if (!tech.authenticate(sectorIndex, sectorKey))
             return false
-        Log.d(TAG, "Authenticatied on sector $sectorIndex, bundle ${sectorKey.bundle}")
+        Log.d(TAG, "Authenticated on sector $sectorIndex, bundle ${sectorKey.bundle}, key ${sectorKey.key.toHexString()}, type ${sectorKey.type}")
         if (!mPreferredBundles.contains(sectorKey.bundle))
             mPreferredBundles.add(sectorKey.bundle)
         return true

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/classic/ClassicBlock.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/classic/ClassicBlock.kt
@@ -30,7 +30,7 @@ import kotlinx.serialization.Transient
 class ClassicBlock(@SerialName("data") private val mData: ImmutableByteArray) {
     @Transient
     val isUnauthorized: Boolean
-        get() = mData == ImmutableByteArray.of(0x04)
+        get() = mData == ImmutableByteArray.of(0x04) || mData.isEmpty()
 
     @Transient
     val data: ImmutableByteArray

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/classic/ClassicReader.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/classic/ClassicReader.kt
@@ -116,7 +116,18 @@ object ClassicReader {
                             ClassicSectorKey.KeyType.B) ?: false,
                             ClassicSectorKey.KeyType.B)
                     if (correctKeyB != null)
-                        sector = ClassicSector.create(ClassicReader.readSectorWithKey(tech, sectorIndex, correctKey))
+                        sector = ClassicSector.create(ClassicReader.readSectorWithKey(tech, sectorIndex, correctKeyB))
+                    // In cases of readable keyB, tag shouldn't succeed auth at all
+                    // yet some clones succeed auth but then fail to read any blocks.
+                } else if (sector.key?.type == ClassicSectorKey.KeyType.B
+                        && sector.blocks.all { it.isUnauthorized }) {
+                    val correctKeyA = auth.authenticate(
+                            tech, feedbackInterface,
+                            sectorIndex, cardType?.isDynamicKeys(sectors, sectorIndex,
+                            ClassicSectorKey.KeyType.A) ?: false,
+                            ClassicSectorKey.KeyType.A)
+                    if (correctKeyA != null)
+                        sector = ClassicSector.create(ClassicReader.readSectorWithKey(tech, sectorIndex, correctKeyA))
                 }
 
                 sectors.add(sector)

--- a/src/main/java/au/id/micolous/metrodroid/card/classic/ClassicCardTechAndroid.kt
+++ b/src/main/java/au/id/micolous/metrodroid/card/classic/ClassicCardTechAndroid.kt
@@ -22,11 +22,13 @@
 
 package au.id.micolous.metrodroid.card.classic
 
+import android.nfc.TagLostException
 import android.nfc.tech.MifareClassic
 import au.id.micolous.metrodroid.card.wrapAndroidExceptions
 import au.id.micolous.metrodroid.key.ClassicSectorKey
 import au.id.micolous.metrodroid.util.ImmutableByteArray
 import au.id.micolous.metrodroid.util.toImmutable
+import java.io.IOException
 
 class ClassicCardTechAndroid(private val tech: MifareClassic,
                              override val tagId: ImmutableByteArray) : ClassicCardTech {
@@ -44,6 +46,12 @@ class ClassicCardTechAndroid(private val tech: MifareClassic,
     override val sectorCount = tech.sectorCount
 
     override fun readBlock(block: Int): ImmutableByteArray = wrapAndroidExceptions {
-        tech.readBlock(block).toImmutable()
+        try {
+            tech.readBlock(block).toImmutable()
+        } catch (e: TagLostException) {
+            throw e
+        } catch (e: IOException) {
+            ImmutableByteArray.empty()
+        }
     }
 }


### PR DESCRIPTION
1. Some cards have broken auth responses and successfuly authenticate with
a readable B key. Detect this case and continue searching for key A
2. In Android Q, readBlock on unauthorized block returns an exception instead of
byteArrayOf(0x04). So assume any IOException other than TagLost is an
authentication error.
3. Make log statement a bit more verbose