### PR TITLE
TransactionTrip: Skip topup transactions while merging.

### DIFF
--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/Transaction.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/Transaction.kt
@@ -79,6 +79,9 @@ abstract class Transaction : Parcelable, Comparable<Transaction> {
     open val isRejected: Boolean
         get() = false
 
+    open val isTransparent: Boolean
+        get() = mode in listOf(Trip.Mode.TICKET_MACHINE, Trip.Mode.VENDING_MACHINE)
+
     open fun getAgencyName(isShort: Boolean) : String? = null
 
     open fun shouldBeMerged(other: Transaction): Boolean {

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/TransactionTrip.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/TransactionTrip.kt
@@ -148,13 +148,13 @@ abstract class TransactionTripAbstract: Trip() {
                   factory: (Transaction) -> TransactionTripAbstract):
                 List<TransactionTripAbstract> {
             val timedTransactions = mutableListOf<Pair<Transaction, TimestampFull>>()
-            val timelessTransactions = mutableListOf<Transaction>()
+            val unmergeableTransactions = mutableListOf<Transaction>()
             for (transaction in transactionsIn) {
                 val ts = transaction.timestamp
-                if (ts is TimestampFull)
+                if (!transaction.isTransparent && ts is TimestampFull)
                     timedTransactions.add(Pair(transaction, ts))
                 else
-                    timelessTransactions.add(transaction)
+                    unmergeableTransactions.add(transaction)
             }
             val transactions = timedTransactions.sortedBy { it.second.timeInMillis }
             val trips = mutableListOf<TransactionTripAbstract>()
@@ -169,7 +169,7 @@ abstract class TransactionTripAbstract: Trip() {
                 else
                     trips.add(factory(first))
             }
-            return trips + timelessTransactions.map { factory(it) }
+            return trips + unmergeableTransactions.map { factory(it) }
         }
     }
 }


### PR DESCRIPTION
Most systems do not record seconds. It's common to topup and go through
the gate in the same minute. In this case topup may end up being sorted after
tap-in and hence prevent tap-in and tap-out merging.