### PR TITLE
Cleanup locked app list handling

### DIFF
--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/desfire/DesfireCardReader.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/desfire/DesfireCardReader.kt
@@ -67,13 +67,13 @@ object DesfireCardReader {
                 appIds = desfireTag.getAppList()
                 appListLocked = false
             } catch (e: UnauthorizedException) {
-                appIds = IntArray(32) { 0x425300 + it }
+                appIds = DesfireCardTransitRegistry.allFactories.flatMap { it.hiddenAppIds.orEmpty() }.toIntArray()
                 appListLocked = true
             }
             var maxProgress = appIds.size
             var progress = 0
 
-            val f = DesfireCardTransitRegistry.allFactories.find { it.earlyCheck(appIds) }
+            val f = if (appListLocked) null else DesfireCardTransitRegistry.allFactories.find { it.earlyCheck(appIds) }
             val i = f?.getCardInfo(appIds)
             if (i != null) {
                 Log.d(TAG, "Early Card Info: ${i.name}")

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/desfire/DesfireCardTransitFactory.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/desfire/DesfireCardTransitFactory.kt
@@ -32,4 +32,7 @@ interface DesfireCardTransitFactory : CardTransitFactory<DesfireCard> {
 
     override fun check(card: DesfireCard): Boolean = earlyCheck(card.applications.keys.toIntArray())
     fun createUnlocker(appIds: Int, manufData: ImmutableByteArray): DesfireUnlocker? = null
+
+    // App IDs that are probed if we can't retrieve application list
+    val hiddenAppIds: List<Int>? get() = null
 }

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/unknown/UnauthorizedDesfireTransitData.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/unknown/UnauthorizedDesfireTransitData.kt
@@ -34,6 +34,9 @@ class UnauthorizedDesfireTransitData (override val cardName: String): Unauthoriz
 
             override fun parseTransitIdentity(card: DesfireCard)
                     = TransitIdentity(getName(card), null)
+
+            override val hiddenAppIds: List<Int>
+                get() = List(32) { 0x425300 + it }
         }
 
         private data class UnauthorizedType(


### PR DESCRIPTION
This moves app ID list to transit data and so allows reading in future other
cards with locked PICC without putting IDs in card/desfire directory