### PR TITLE
Support desfire cards with locked directory list 

### DIFF
--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/UnauthorizedException.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/UnauthorizedException.kt
@@ -19,5 +19,5 @@
 
 package au.id.micolous.metrodroid.card
 
-class UnauthorizedException (override val message: String = "Unauthorized"): IllegalStateException()
+open class UnauthorizedException (override val message: String = "Unauthorized"): IllegalStateException()
 class NotFoundException (override val message: String = "Not found"): IllegalStateException()

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/desfire/DesfireApplication.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/desfire/DesfireApplication.kt
@@ -37,7 +37,9 @@ data class DesfireApplication(
         private val files: Map<Int, RawDesfireFile>,
         @XMLId("auth-log")
         @Optional
-        private val authLog: List<DesfireAuthLog> = emptyList()) {
+        private val authLog: List<DesfireAuthLog> = emptyList(),
+        @Optional
+        private val dirListLocked: Boolean = false) {
     @Transient
     val interpretedFiles: Map<Int, DesfireFile> = files.mapValues { (_, v) -> DesfireFile.create(v) }
     @Transient

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/desfire/DesfireCardReader.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/desfire/DesfireCardReader.kt
@@ -67,13 +67,13 @@ object DesfireCardReader {
                 appIds = desfireTag.getAppList()
                 appListLocked = false
             } catch (e: UnauthorizedException) {
-                appIds = IntArray(32) { 0x425300 + it }
+                appIds = DesfireCardTransitRegistry.allFactories.flatMap { it.hiddenAppIds.orEmpty() }.toIntArray()
                 appListLocked = true
             }
             var maxProgress = appIds.size
             var progress = 0
 
-            val f = DesfireCardTransitRegistry.allFactories.find { it.earlyCheck(appIds) }
+            val f = if (appListLocked) null else DesfireCardTransitRegistry.allFactories.find { it.earlyCheck(appIds) }
             val i = f?.getCardInfo(appIds)
             if (i != null) {
                 Log.d(TAG, "Early Card Info: ${i.name}")

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/desfire/DesfireCardTransitFactory.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/desfire/DesfireCardTransitFactory.kt
@@ -32,4 +32,7 @@ interface DesfireCardTransitFactory : CardTransitFactory<DesfireCard> {
 
     override fun check(card: DesfireCard): Boolean = earlyCheck(card.applications.keys.toIntArray())
     fun createUnlocker(appIds: Int, manufData: ImmutableByteArray): DesfireUnlocker? = null
+
+    // App IDs that are probed if we can't retrieve application list
+    val hiddenAppIds: List<Int>? get() = null
 }

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/desfire/files/RawDesfireFile.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/desfire/files/RawDesfireFile.kt
@@ -37,4 +37,6 @@ data class RawDesfireFile (
         val error: String? = null,
         @Optional
         @XMLId("unauthorized")
-        val isUnauthorized: Boolean = false)
+        val isUnauthorized: Boolean = false,
+        @Optional
+        val readCommand: Byte? = null)

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/desfire/files/StandardDesfireFile.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/desfire/files/StandardDesfireFile.kt
@@ -26,5 +26,5 @@ package au.id.micolous.metrodroid.card.desfire.files
 
 import au.id.micolous.metrodroid.card.desfire.settings.StandardDesfireFileSettings
 
-data class StandardDesfireFile(override val fileSettings: StandardDesfireFileSettings,
+data class StandardDesfireFile(override val fileSettings: StandardDesfireFileSettings?,
                                override val raw: RawDesfireFile) : DesfireFile()

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/desfire/files/ValueDesfireFile.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/desfire/files/ValueDesfireFile.kt
@@ -23,7 +23,7 @@ import au.id.micolous.metrodroid.card.desfire.settings.DesfireFileSettings
 /**
  * Represents a value file in Desfire
  */
-data class ValueDesfireFile (override val fileSettings: DesfireFileSettings,
+data class ValueDesfireFile (override val fileSettings: DesfireFileSettings?,
                              override val raw: RawDesfireFile): DesfireFile() {
     val value: Int
       get() = data.byteArrayToIntReversed()

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/unknown/UnauthorizedDesfireTransitData.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/unknown/UnauthorizedDesfireTransitData.kt
@@ -34,6 +34,9 @@ class UnauthorizedDesfireTransitData (override val cardName: String): Unauthoriz
 
             override fun parseTransitIdentity(card: DesfireCard)
                     = TransitIdentity(getName(card), null)
+
+            override val hiddenAppIds: List<Int>
+                get() = List(32) { 0x425300 + it }
         }
 
         private data class UnauthorizedType(


### PR DESCRIPTION
MagnaCarta locks down the directory list. It doesn't prevent us from iterating
through files as there are only 256 possible file IDs and only 32 that are
ever used in any parser. However we can't read file settings in this case
so instead we have to try all 3 possible read command and then save which one
worked for recreating the parsed files