### PR TITLE
EMV fixups

### DIFF
--- a/src/androidTest/java/au/id/micolous/metrodroid/test/TLVDroidTest.kt
+++ b/src/androidTest/java/au/id/micolous/metrodroid/test/TLVDroidTest.kt
@@ -1,0 +1,41 @@
+/*
+ * TLVDroidTest.kt
+ *
+ * Copyright 2019 Michael Farrell <micolous+git@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package au.id.micolous.metrodroid.test
+
+import au.id.micolous.metrodroid.card.iso7816.ISO7816TLV
+import au.id.micolous.metrodroid.util.ImmutableByteArray
+import kotlin.test.Test
+import kotlin.test.assertNull
+
+class TLVDroidTest : BaseInstrumentedTest() {
+    @Test
+    fun testFindDefiniteReallyLong() {
+        // TODO: Move into common tests
+        // This calls Log.e (by design), which fails on Android mock environments.
+
+        // tag 50 (parent, definite long, 0xffffffffffffffff bytes)
+        // -> tag 51: "hello world"
+        val d = (ImmutableByteArray.fromHex("5088") +
+                ImmutableByteArray(8) { 0xff.toByte() } +
+                ImmutableByteArray.fromHex("0e510b68656c6c6f20776f726c64"))
+
+        // Should fail
+        assertNull(ISO7816TLV.findBERTLV(d, "51", false))
+    }
+}

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/iso7816/ISO7816TLV.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/iso7816/ISO7816TLV.kt
@@ -1,7 +1,7 @@
 /*
  * ISO7816TLV.kt
  *
- * Copyright 2018 Michael Farrell <micolous+git@gmail.com>
+ * Copyright 2018-2019 Michael Farrell <micolous+git@gmail.com>
  * Copyright 2018 Google
  *
  * This program is free software: you can redistribute it and/or modify
@@ -21,28 +21,102 @@
 package au.id.micolous.metrodroid.card.iso7816
 
 import au.id.micolous.metrodroid.multi.FormattedString
+import au.id.micolous.metrodroid.multi.Log
 import au.id.micolous.metrodroid.ui.ListItem
 import au.id.micolous.metrodroid.ui.ListItemRecursive
 import au.id.micolous.metrodroid.util.ImmutableByteArray
 
+/**
+ * Utilities for decoding BER-TLV values.
+ *
+ * Reference: https://en.wikipedia.org/wiki/X.690#BER_encoding
+ */
 object ISO7816TLV {
-    // return: <leadBits, id, idlen>
+    private const val TAG = "ISO7816TLV"
+    private const val MAX_TLV_FIELD_LENGTH = 0xffff
+
+    /**
+     * Gets the _length_ of a TLV tag identifier octets.
+     *
+     * @param buf TLV data buffer
+     * @param p Offset within [buf] to read from
+     * @return The number of bytes for this tag's identifier octets.
+     */
     private fun getTLVIDLen(buf: ImmutableByteArray, p: Int): Int {
+        // One byte version: if the lower 5 bits (tag number) != 0x1f.
         if (buf[p].toInt() and 0x1f != 0x1f)
             return 1
+
+        // Multi-byte version: if the first byte has the lower 5 bits == 0x1f then subsequent
+        // bytes contain the tag number. Bit 8 is set when there (is/are) more byte(s) for the
+        // tag number.
         var len = 1
         while (buf[p + len++].toInt() and 0x80 != 0);
         return len
     }
 
-    // return lenlen, lenvalue
-    private fun decodeTLVLen(buf: ImmutableByteArray, p: Int): IntArray {
+    /**
+     * Decodes the length octets for a TLV tag.
+     *
+     * @param buf TLV data buffer
+     * @param p Offset within [buf] to start reading the length octets from
+     * @return A `[Triple]<[Int], [Int]>`: the number of bytes for this tag's length octets, the
+     * length of the _contents octets_, and the length of the _end of contents octets_.
+     *
+     * Returns `null` if invalid.
+     */
+    private fun decodeTLVLen(buf: ImmutableByteArray, p: Int): Triple<Int, Int, Int>? {
         val headByte = buf[p].toInt() and 0xff
-        if (headByte shr 7 == 0)
-            return intArrayOf(1, headByte and 0x7f)
+        if (headByte shr 7 == 0) {
+            // Definite, short form (1 byte)
+            // Length is the lower 7 bits of the first byte
+            return Triple(1, headByte and 0x7f, 0)
+        }
+
+        // Decode other forms
         val numfollowingbytes = headByte and 0x7f
-        return intArrayOf(1 + numfollowingbytes,
-                buf.byteArrayToInt(p + 1, numfollowingbytes))
+        if (numfollowingbytes == 0) {
+            // Indefinite form.
+            // Value is terminated by two NULL bytes.
+            val endPos = buf.indexOf(ImmutableByteArray.empty(2), p + 1)
+            return if (endPos == -1) {
+                // No null terminators!
+                Log.e(TAG, "No null terminator for indef tag at $p!")
+                null
+            } else {
+                Triple(1, endPos - p - 1, 2)
+            }
+        } else if (numfollowingbytes >= 8) {
+            // Definite, long form
+            //
+            // We got 8 or more following bytes for storing the length.  We can only decode
+            // this if all bytes but the last 8 are NULL, and the 8th-to-last top bit is also 0.
+            val topBytes = buf.sliceOffLen(p + 1, numfollowingbytes - 8)
+            if (!(topBytes.isEmpty() || topBytes.isAllZero()) ||
+                    buf[p + 1 + numfollowingbytes - 7].toInt() and 0x80 == 0x80) {
+                // We can't decode
+                Log.e(TAG, "Definite long form at $p is too big for signed long " +
+                        "($numfollowingbytes), cannot decode!")
+                return null
+            }
+        }
+
+        // Definite form, long form
+        val length = buf.byteArrayToInt(p + 1, numfollowingbytes)
+
+        if (length > MAX_TLV_FIELD_LENGTH) {
+            // 64 KiB field length is enough for anyone(tm). :)
+
+            Log.e(TAG, "Definite long form at $p of > $MAX_TLV_FIELD_LENGTH bytes " +
+                    "($length)")
+            return null
+        } else if (length < 0) {
+            // Shouldn't get negative values either.
+            Log.e(TAG, "Definite log form at $p has negative value? ($length)")
+            return null
+        }
+
+        return Triple(1 + numfollowingbytes, length, 0)
     }
 
     /**
@@ -54,25 +128,86 @@ object ISO7816TLV {
     fun berTlvIterate(buf: ImmutableByteArray) :
             Sequence<Triple<ImmutableByteArray, ImmutableByteArray, ImmutableByteArray>> {
         return sequence {
+            // Skip null bytes at start:
+            // "Before, between, or after TLV-coded data objects, '00' bytes without any meaning may
+            // occur (for example, due to erased or modified TLV-coded data objects)."
+            var p = buf.indexOfFirst { it != 0.toByte() }
+
+            if (p == -1) {
+                // No non-null bytes
+                return@sequence
+            }
+
             // Skip ID
-            var p = getTLVIDLen(buf, 0)
-            val (startoffset, alldatalen) = decodeTLVLen(buf, p)
+            p = getTLVIDLen(buf, 0)
+            val (startoffset, alldatalen, alleoclen) = decodeTLVLen(buf, p) ?: return@sequence
+            if (p < 0 || startoffset < 0 || alldatalen < 0 || alleoclen < 0) {
+                Log.w(TAG, "Invalid TLV reading header: p=$p, startoffset=$startoffset, " +
+                        "alldatalen=$alldatalen, alleoclen=$alleoclen")
+                return@sequence
+            }
+
             p += startoffset
             val fulllen = p + alldatalen
 
             while (p < fulllen) {
-                val idlen = getTLVIDLen(buf, p)
-                val (lenlen, datalen) = decodeTLVLen(buf, p + idlen)
-                yield(Triple(buf.sliceOffLen(p, idlen), // id
-                        buf.sliceOffLen(p, idlen + lenlen), // header
-                        buf.sliceOffLen(p + idlen + lenlen, datalen))) // data
+                // Skip null bytes
+                if (buf[p] == 0.toByte()) {
+                    p++
+                    continue
+                }
 
-                p += idlen + lenlen + datalen
+                val idlen = getTLVIDLen(buf, p)
+
+                if (p + idlen >= buf.size) break // EOF
+                val id = buf.sliceOffLenSafe(p, idlen)
+                if (id == null) {
+                    Log.w(TAG, "Invalid TLV ID data at $p: out of bounds")
+                    break
+                }
+
+                // Log.d(TAG, "($p) id=${id.getHexString()}")
+
+                val (hlen, datalen, eoclen) = decodeTLVLen(buf, p + idlen) ?: break
+
+                if (idlen < 0 || hlen < 0 || datalen < 0 || eoclen < 0) {
+                    // Invalid lengths, abort!
+                    Log.w(TAG, "Invalid TLV data at $p (<0): idlen=$idlen, hlen=$hlen, " +
+                            "datalen=$datalen, eoclen=$eoclen")
+                    break
+                }
+
+                val header = buf.sliceOffLenSafe(p, idlen + hlen)
+                val data = buf.sliceOffLenSafe(p + idlen + hlen, datalen)
+
+                if (header == null || data == null) {
+                    // Invalid ranges, abort!
+                    Log.w(TAG, "Invalid TLV data at $p: out of bounds")
+                    break
+                }
+
+                if ((id.isAllZero() || id.isEmpty()) && (header.isEmpty() || header.isAllZero())
+                        && data.isEmpty()) {
+                    // Skip empty tag
+                    continue
+                }
+
+                // Log.d(TAG, "($p) id=${id.toHexString()}, header=${header.getHexString()}, " +
+                //         "data=${data.getHexString()}")
+                yield(Triple(id, header, data))
+                p += idlen + hlen + datalen + eoclen
             }
         }
     }
 
     // TODO: Replace with Sequence
+    /**
+     * Iterates over Processing Options Data Object List (PDOL), tag 9f38.
+     *
+     * This is a list of tags needed by the ICC for the GET PROCESSING OPTIONS (GPO) command.
+     *
+     * The lengths in this context are the expected length in the request.
+     */
     fun pdolIterate(buf: ImmutableByteArray,
                     iterator: (id: ImmutableByteArray,
                                len: Int) -> Unit) {
@@ -80,7 +215,9 @@ object ISO7816TLV {
 
         while (p < buf.size) {
             val idlen = getTLVIDLen(buf, p)
-            val (lenlen, datalen) = decodeTLVLen(buf, p + idlen)
+            if (idlen < 0) break
+            val (lenlen, datalen, eoclen) = decodeTLVLen(buf, p + idlen) ?: break
+            if (lenlen < 0 || datalen < 0 || eoclen != 0) break
             iterator(buf.sliceOffLen(p, idlen), datalen)
 
             p += idlen + lenlen
@@ -147,7 +284,8 @@ object ISO7816TLV {
 
     fun removeTlvHeader(buf: ImmutableByteArray): ImmutableByteArray {
         val p = getTLVIDLen(buf, 0)
-        val (startoffset, datalen) = decodeTLVLen(buf, p)
+        // todo check if past eof
+        val (startoffset, datalen, eoclen) = decodeTLVLen(buf, p) ?: return ImmutableByteArray.empty()
         return buf.sliceOffLen(p+startoffset, datalen)
     }
 

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/emv/EmvData.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/emv/EmvData.kt
@@ -30,9 +30,19 @@ internal object EmvData {
 
     const val TAG_NAME1 = "50"
     const val T2Data = "57"
+    const val TAG_TRANSACTION_CURRENCY_CODE = "5f2a"
+    const val TAG_TERMINAL_VERIFICATION_RESULTS = "95"
+    const val TAG_TRANSACTION_DATE = "9a"
+    const val TAG_TRANSACTION_TYPE = "9c"
+    const val TAG_AMOUNT_AUTHORISED = "9f02"
+    const val TAG_AMOUNT_OTHER = "9f03"
+    const val TAG_TRANSACTION_TIME = "9f21"
     const val TAG_NAME2 = "9f12"
+    const val TAG_TERMINAL_COUNTRY_CODE = "9f1a"
+    const val TAG_UNPREDICTABLE_NUMBER = "9f37"
     const val TAG_PDOL = "9f38"
     const val LOG_ENTRY = "9f4d"
+    const val TAG_TERMINAL_TRANSACTION_QUALIFIERS = "9f66"
 
     // TODO: i18n
     val TAGMAP = mapOf(
@@ -65,6 +75,7 @@ internal object EmvData {
             "94" to TagDesc(R.string.emv_application_file_locator, DUMP_SHORT),
             "9f07" to HIDDEN_TAG, // Application Usage Control
             "9f08" to HIDDEN_TAG, // Application Version Number
+            "9f0b" to TagDesc(R.string.card_holders_name, ASCII),
             "9f0d" to HIDDEN_TAG, // Issuer Action Code - Default
             "9f0e" to HIDDEN_TAG, // Issuer Action Code - Denial
             "9f0f" to HIDDEN_TAG, // Issuer Action Code - Online

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/emv/EmvLogEntry.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/emv/EmvLogEntry.kt
@@ -28,6 +28,10 @@ import au.id.micolous.metrodroid.time.TimestampFull
 import au.id.micolous.metrodroid.transit.TransitCurrency
 import au.id.micolous.metrodroid.transit.Trip
 import au.id.micolous.metrodroid.transit.emv.EmvData.TAGMAP
+import au.id.micolous.metrodroid.transit.emv.EmvData.TAG_AMOUNT_AUTHORISED
+import au.id.micolous.metrodroid.transit.emv.EmvData.TAG_TRANSACTION_CURRENCY_CODE
+import au.id.micolous.metrodroid.transit.emv.EmvData.TAG_TRANSACTION_DATE
+import au.id.micolous.metrodroid.transit.emv.EmvData.TAG_TRANSACTION_TIME
 import au.id.micolous.metrodroid.util.ImmutableByteArray
 import au.id.micolous.metrodroid.util.NumberUtils
 
@@ -35,8 +39,8 @@ import au.id.micolous.metrodroid.util.NumberUtils
 @Parcelize
 data class EmvLogEntry(private val values: Map<String, ImmutableByteArray>) : Trip() {
     override val startTimestamp get(): Timestamp? {
-        val dateBin = values["9a"] ?: return null
-        val timeBin = values["9f21"]
+        val dateBin = values[TAG_TRANSACTION_DATE] ?: return null
+        val timeBin = values[TAG_TRANSACTION_TIME]
         if (timeBin != null)
             return TimestampFull(tz = MetroTimeZone.UNKNOWN,
                     year = 2000 + NumberUtils.convertBCDtoInteger(dateBin[0].toInt()),
@@ -51,12 +55,12 @@ data class EmvLogEntry(private val values: Map<String, ImmutableByteArray>) : Tr
     }
 
     override val fare get(): TransitCurrency? {
-        val amountBin = values["9f02"] ?: return null
+        val amountBin = values[TAG_AMOUNT_AUTHORISED] ?: return null
         val amount = amountBin.fold(0L) { acc, b ->
             acc * 100 + NumberUtils.convertBCDtoInteger(b.toInt() and 0xff)
         }
 
-        val codeBin = values["5f2a"] ?: return TransitCurrency.XXX(amount.toInt())
+        val codeBin = values[TAG_TRANSACTION_CURRENCY_CODE] ?: return TransitCurrency.XXX(amount.toInt())
         val code = NumberUtils.convertBCDtoInteger(codeBin.byteArrayToInt())
 
         return TransitCurrency(amount.toInt(), code)
@@ -65,8 +69,7 @@ data class EmvLogEntry(private val values: Map<String, ImmutableByteArray>) : Tr
     override val mode get() = Mode.POS
 
     override val routeName get() = values.entries.filter {
-        it.key != "9f02" && it.key != "5f2a"
-                && it.key != "9a" && it.key != "9f21"
+        !HANDLED_TAGS.contains(it.key)
     }.joinToString {
         val tag = TAGMAP[it.key]
         if (tag == null)
@@ -76,7 +79,15 @@ data class EmvLogEntry(private val values: Map<String, ImmutableByteArray>) : Tr
     }
 
     companion object {
+        private val HANDLED_TAGS = listOf(
+                TAG_AMOUNT_AUTHORISED,
+                TAG_TRANSACTION_CURRENCY_CODE,
+                TAG_TRANSACTION_TIME,
+                TAG_TRANSACTION_DATE)
+
         fun parseEmvTrip(record: ImmutableByteArray, format: ImmutableByteArray): EmvLogEntry? {
+            // EMV transactions consist of the PDOL (format) which references offsets in the
+            // record data.
             val values = mutableMapOf<String, ImmutableByteArray>()
             var p = 0
             val dol = ISO7816TLV.removeTlvHeader(format)

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/util/ImmutableByteArray.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/util/ImmutableByteArray.kt
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2014 Eric Butler <eric@codebutler.com>
  * Copyright (C) 2019 Google
+ * Copyright (C) 2019 Michael Farrell <micolous+git@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -118,6 +119,61 @@ class ImmutableByteArray private constructor(
             mData.size >= other.size &&
             mData.sliceArray(0 until other.size).contentEquals(other)
     fun startsWith(other: ImmutableByteArray) = startsWith(other.mData)
+
+    /**
+     * Returns the first index of [needle], or `-1` if it does not contain [needle].
+     *
+     * @param needle Array to search for
+     * @param start Index to start searching from. Defaults to the start of the array.
+     * @param end Index to end searching at. Defaults to the end of the array.
+     */
+    fun indexOf(needle: ImmutableByteArray, start: Int = 0, end: Int = size): Int {
+        val needleSize = needle.size
+
+        if (start < 0 || start > lastIndex || end > size || start > end) {
+            // Impossible request
+            return -1
+        } else if (needle.isEmpty()) {
+            // We can search for nothing in the space of something
+            return start
+        } else if ((start + needleSize) == end) {
+            // Optimise -- do a substring check
+            return if (start == 0 && end == size) {
+                // Whole string check
+                if (contentEquals(needle)) 0 else -1
+            } else {
+                // Need to slice first
+                if (sliceArray(start until end).contentEquals(needle)) start else -1
+            }
+        } else if ((start + needleSize) > end) {
+            // We can't possibly fulfill that request
+            return -1
+        }
+
+        var p = 0
+        for (i in start until end) {
+            if ((i + needleSize - p) > end) {
+                // Can't possibly find a good match now.
+                break
+            }
+
+            if (mData[i] == needle[p]) {
+                p++
+                if (p == needleSize) {
+                    // Success!
+                    return i + 1 - needleSize
+                } else {
+                    // Need more...
+                    continue
+                }
+            } else {
+                p = 0
+            }
+        }
+
+        // Failure
+        return -1
+    }
 
     fun map(function: (Byte) -> Byte) = ImmutableByteArray(
             mData = ByteArray(size) { it -> function(mData[it]) }

--- a/src/commonTest/kotlin/au/id/micolous/metrodroid/test/ImmutableByteArrayTest.kt
+++ b/src/commonTest/kotlin/au/id/micolous/metrodroid/test/ImmutableByteArrayTest.kt
@@ -1,0 +1,88 @@
+/*
+ * ImmutableByteArrayTest.kt
+ *
+ * Copyright 2019 Michael Farrell <micolous+git@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package au.id.micolous.metrodroid.test
+
+import au.id.micolous.metrodroid.util.ImmutableByteArray
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ImmutableByteArrayTest {
+    @Test
+    fun testIndexOfAtStart() {
+        // Check single byte
+        val s = ImmutableByteArray.fromHex("0102030405")
+        val n = ImmutableByteArray.fromHex("01")
+
+        assertEquals(0, s.indexOf(n))
+        assertEquals(-1, s.indexOf(n, 1))
+        assertEquals(-1, s.indexOf(n, end = 0))
+
+        // Check multiple bytes
+        val n2 = ImmutableByteArray.fromHex("010203")
+        assertEquals(0, s.indexOf(n2))
+        assertEquals(-1, s.indexOf(n2, 1))
+
+        // Check whole bytes match
+        assertEquals(0, s.indexOf(s))
+        assertEquals(-1, s.indexOf(s, 1))
+        assertEquals(-1, s.indexOf(s, end = 1))
+        assertEquals(-1, s.indexOf(s, end = 2))
+    }
+
+    @Test
+    fun testIndexOfAtMiddle() {
+        // Check single byte
+        val s = ImmutableByteArray.fromHex("0102030405")
+        val n = ImmutableByteArray.fromHex("03")
+
+        assertEquals(2, s.indexOf(n))
+        assertEquals(2, s.indexOf(n, 1))
+        assertEquals(2, s.indexOf(n, 2))
+        assertEquals(-1, s.indexOf(n, 3))
+        assertEquals(-1, s.indexOf(n, end = 0))
+        assertEquals(-1, s.indexOf(n, end = 1))
+        assertEquals(-1, s.indexOf(n, end = 2))
+
+        // Check multiple bytes
+        val n2 = ImmutableByteArray.fromHex("0304")
+        assertEquals(2, s.indexOf(n2))
+        assertEquals(2, s.indexOf(n2, 1))
+        assertEquals(2, s.indexOf(n2, 2))
+        assertEquals(-1, s.indexOf(n2, 3))
+
+        assertEquals(-1, s.indexOf(n2, end = 0))
+        assertEquals(-1, s.indexOf(n2, end = 1))
+        assertEquals(-1, s.indexOf(n2, end = 2))
+
+        assertEquals(-1, s.indexOf(n2, 1, 1))
+        assertEquals(-1, s.indexOf(n2, 1, 2))
+        assertEquals(-1, s.indexOf(n2, 1, 3))
+        assertEquals(2, s.indexOf(n2, 1, 4))
+        assertEquals(2, s.indexOf(n2, 1, 5))
+
+        assertEquals(-1, s.indexOf(n2, 2, 2))
+        assertEquals(-1, s.indexOf(n2, 2, 3))
+        assertEquals(2, s.indexOf(n2, 2, 4))
+        assertEquals(2, s.indexOf(n2, 2, 5))
+
+        assertEquals(-1, s.indexOf(n2, 3, 4))
+        assertEquals(-1, s.indexOf(n2, 3, 5))
+        assertEquals(-1, s.indexOf(n2, 3, 6))
+    }
+}

--- a/src/commonTest/kotlin/au/id/micolous/metrodroid/test/TLVTest.kt
+++ b/src/commonTest/kotlin/au/id/micolous/metrodroid/test/TLVTest.kt
@@ -22,7 +22,6 @@ import au.id.micolous.metrodroid.card.iso7816.ISO7816TLV
 import au.id.micolous.metrodroid.util.ImmutableByteArray
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 class TLVTest {
     @Test
@@ -76,17 +75,5 @@ class TLVTest {
         val e = ImmutableByteArray.fromASCII("hello world")
 
         assertEquals(e, ISO7816TLV.findBERTLV(d, "51", false))
-    }
-
-    @Test
-    fun testFindDefiniteReallyLong() {
-        // tag 50 (parent, definite long, 0xffffffffffffffff bytes)
-        // -> tag 51: "hello world"
-        val d = (ImmutableByteArray.fromHex("5088") +
-                ImmutableByteArray(8) { 0xff.toByte() } +
-                ImmutableByteArray.fromHex("0e510b68656c6c6f20776f726c64"))
-
-        // Should fail
-        assertNull(ISO7816TLV.findBERTLV(d, "51", false))
     }
 }

--- a/src/commonTest/kotlin/au/id/micolous/metrodroid/test/TLVTest.kt
+++ b/src/commonTest/kotlin/au/id/micolous/metrodroid/test/TLVTest.kt
@@ -1,0 +1,92 @@
+/*
+ * TLVTest.kt
+ *
+ * Copyright 2019 Michael Farrell <micolous+git@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package au.id.micolous.metrodroid.test
+
+import au.id.micolous.metrodroid.card.iso7816.ISO7816TLV
+import au.id.micolous.metrodroid.util.ImmutableByteArray
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class TLVTest {
+    @Test
+    fun testFindDefiniteShort() {
+        // tag 50 (parent, definite short)
+        // -> tag 51: "hello world"
+        val d = ImmutableByteArray.fromHex("500e510b68656c6c6f20776f726c64")
+        val e = ImmutableByteArray.fromASCII("hello world")
+
+        assertEquals(e, ISO7816TLV.findBERTLV(d, "51", false))
+    }
+
+    @Test
+    fun testFindIndefinite() {
+        // tag 50 (parent, indefinite)
+        // -> tag 51: "hello world"
+        // end-of-contents octets
+        val d = ImmutableByteArray.fromHex("5080510b68656c6c6f20776f726c640000")
+        val e = ImmutableByteArray.fromASCII("hello world")
+
+        assertEquals(e, ISO7816TLV.findBERTLV(d, "51", false))
+    }
+
+    @Test
+    fun testFindDefinite1() {
+        // tag 50 (parent, definite long, 1 byte)
+        // -> tag 51: "hello world"
+        val d = ImmutableByteArray.fromHex("50810e510b68656c6c6f20776f726c64")
+        val e = ImmutableByteArray.fromASCII("hello world")
+
+        assertEquals(e, ISO7816TLV.findBERTLV(d, "51", false))
+    }
+
+    @Test
+    fun testFindDefinite7() {
+        // tag 50 (parent, definite long, 7 bytes)
+        // -> tag 51: "hello world"
+        val d = ImmutableByteArray.fromHex("50870000000000000e510b68656c6c6f20776f726c64")
+        val e = ImmutableByteArray.fromASCII("hello world")
+
+        assertEquals(e, ISO7816TLV.findBERTLV(d, "51", false))
+    }
+
+    @Test
+    fun testFindDefinite126() {
+        // tag 50 (parent, definite long, 126 bytes)
+        // -> tag 51: "hello world"
+        val d = (ImmutableByteArray.fromHex("50fe") +
+                ImmutableByteArray.empty(125) +
+                ImmutableByteArray.fromHex("0e510b68656c6c6f20776f726c64"))
+        val e = ImmutableByteArray.fromASCII("hello world")
+
+        assertEquals(e, ISO7816TLV.findBERTLV(d, "51", false))
+    }
+
+    @Test
+    fun testFindDefiniteReallyLong() {
+        // tag 50 (parent, definite long, 0xffffffffffffffff bytes)
+        // -> tag 51: "hello world"
+        val d = (ImmutableByteArray.fromHex("5088") +
+                ImmutableByteArray(8) { 0xff.toByte() } +
+                ImmutableByteArray.fromHex("0e510b68656c6c6f20776f726c64"))
+
+        // Should fail
+        assertNull(ISO7816TLV.findBERTLV(d, "51", false))
+    }
+}


### PR DESCRIPTION
* decodeTLVLen now supports indefinite TLV form

* Skip NULL bytes between fields per EMV spec (fixes reading Monzo
  Mastercard -- but no transaction history available)

* Converts decodeTLVLen to use Triple instead of IntArray

* decodeTLVLen now doesn't try to decode larger than 61 bit integers

* decodeTLVLen aborts when getting a field larger than 0xFFFF bytes, which
  should be enough for anyone

* Moves some EMV constants into EmvData

* Add test for TLV decoder