### PR TITLE
LocalizeGenerator: remove drawables list and properly declare inputs …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,11 +42,17 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlinx-serialization'
 
 def generatedLocalizeDir = new File(buildDir, "generated/source/localize")
+def drawableDir = new File(projectDir, "src/main/res/drawable")
+def drawableHdpiDir = new File(projectDir, "src/main/res/drawable-hdpi")
 def stringsXmlFile = new File(projectDir, "src/main/res/values/strings.xml")
 
 task generateLocalize {
+    inputs.file stringsXmlFile
+    inputs.dir drawableDir
+    inputs.dir drawableHdpiDir
+    outputs.dir generatedLocalizeDir
     doLast {
-        LocalizeGenerator.INSTANCE.generateLocalize(generatedLocalizeDir, stringsXmlFile)
+        LocalizeGenerator.INSTANCE.generateLocalize(generatedLocalizeDir, stringsXmlFile, [drawableDir, drawableHdpiDir])
     }
 }
 


### PR DESCRIPTION
…and outputs

Read list of images from files.
Properly declaring inputs should fix the problems with stale R files