### PR TITLE
Add unsigned compile options

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -290,6 +290,13 @@ android {
         disable 'MissingTranslation'
     }
 }
+
+kotlin.sourceSets.all {
+    languageSettings {
+        useExperimentalAnnotation('kotlin.ExperimentalUnsignedTypes')
+    }
+}
+
 androidExtensions {
     // Needed for kotlinx.android.parcel.Parcelize
     experimental = true


### PR DESCRIPTION
This silence the warnings about usage of unsigned types