### PR TITLE
Bring back "Share all" option

### DIFF
--- a/src/main/res/menu/cards_menu.xml
+++ b/src/main/res/menu/cards_menu.xml
@@ -41,6 +41,12 @@
     <item
         android:id="@+id/export_all"
         android:title="@string/export_all">
+        <menu>
+            <item android:id="@+id/share_xml"
+                  android:title="@string/share_xml" />
+            <item android:id="@+id/save_xml"
+                  android:title="@string/save_xml" />
+        </menu>
     </item>
     <item android:id="@+id/deduplicate_cards"
         android:title="@string/deduplicate_cards" />


### PR DESCRIPTION
It fixes the underlying context bug.

Copy all is not useful anymore as the zip is not text