### PR TITLE
ClassicCard: fix edge cases with incomplete reads

### DIFF
--- a/src/androidTest/java/au/id/micolous/metrodroid/test/ClassicCardTest.kt
+++ b/src/androidTest/java/au/id/micolous/metrodroid/test/ClassicCardTest.kt
@@ -1,0 +1,45 @@
+/*
+ * ClassicCardTest.kt
+ *
+ * Copyright 2019 Michael Farrell <micolous+git@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package au.id.micolous.metrodroid.test
+
+import au.id.micolous.metrodroid.card.classic.ClassicCard
+import au.id.micolous.metrodroid.serializers.XmlOrJsonCardFormat
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class ClassicCardTest: CardReaderWithAssetDumpsTest(XmlOrJsonCardFormat()) {
+    @Test
+    fun testIncomplete() {
+        val incompleteFiles = arrayOf(
+                "mfc/mfc-incomplete0.json",
+                "mfc/mfc-incomplete1.json")
+
+        for (path in incompleteFiles) {
+            val c = loadCard<ClassicCard>(path)
+            val classic = c.mifareClassic
+            assertNotNull(classic, path)
+            assertNull(c.manufacturingInfo, path)
+            assertNull(classic.manufacturingInfo, path)
+            assertEquals(1, classic.sectors.size, path)
+            assertEquals(0, classic.sectors[0].blocks.size, path)
+        }
+    }
+}

--- a/src/androidTest/java/au/id/micolous/metrodroid/test/ClassicManufacturerDataTest.kt
+++ b/src/androidTest/java/au/id/micolous/metrodroid/test/ClassicManufacturerDataTest.kt
@@ -1,0 +1,49 @@
+/*
+ * ClassicManufacturerDataTest.kt
+ *
+ * Copyright 2019 Michael Farrell <micolous+git@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package au.id.micolous.metrodroid.test
+
+import au.id.micolous.metrodroid.card.classic.ClassicCard
+import au.id.micolous.metrodroid.card.classic.ClassicCard.Companion.MANUFACTURER_FUDAN
+import au.id.micolous.metrodroid.serializers.classic.MfcCardImporter
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+class ClassicManufacturerDataTest: CardReaderWithAssetDumpsTest(MfcCardImporter()) {
+    @Test
+    fun testFudan() {
+        // Dump is from Bilhete Unico tests
+        val c = loadCard<ClassicCard>("9e4937b0.mfd")
+        assertNotNull(c.mifareClassic)
+
+        val mi = c.manufacturingInfo
+        assertNotNull(mi)
+        assertContainsListItem(MANUFACTURER_FUDAN, mi)
+    }
+
+    @Test
+    fun testNotFudan() {
+        // Dump is from Bilhete Unico tests
+        val c = loadCard<ClassicCard>("7eb2258a.mfd")
+        assertNotNull(c.mifareClassic)
+
+        val mi = c.manufacturingInfo
+        assertNotNull(mi)
+        assertNotContainsListItem(MANUFACTURER_FUDAN, mi)
+    }
+}

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/multi/FormattedString.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/multi/FormattedString.kt
@@ -19,6 +19,16 @@
 
 package au.id.micolous.metrodroid.multi
 
+fun FormattedString.equals(other: Any?): Boolean {
+    return when (other) {
+        null -> false
+        is StringResource -> equals(Localizer.localizeString(other))
+        is FormattedString -> equals(other.toString())
+        is String -> toString() == other
+        else -> false
+    }
+}
+
 expect class FormattedString {
     val unformatted: String
 

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/ui/ListItem.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/ui/ListItem.kt
@@ -45,4 +45,18 @@ open class ListItem(val text1: FormattedString?, val text2: FormattedString?) {
             if (value != null) FormattedString(value) else null)
 
     protected constructor(name: FormattedString) : this(name, null)
+
+    override fun equals(other: Any?): Boolean {
+        return when (other) {
+            null -> false
+            is ListItem -> text1 == other.text1 && text2 == other.text2
+            else -> false
+        }
+    }
+
+    override fun hashCode(): Int {
+        var result = text1?.hashCode() ?: 0
+        result = 31 * result + (text2?.hashCode() ?: 0)
+        return result
+    }
 }

--- a/src/commonTest/assets/mfc/mfc-incomplete0.json
+++ b/src/commonTest/assets/mfc/mfc-incomplete0.json
@@ -1,0 +1,16 @@
+{
+  "tagId": "12345678",
+  "scannedAt": {
+    "timeInMillis": 1,
+    "tz": "Etc/UTC"
+  },
+  "mifareClassic": {
+    "isPartialRead": true,
+    "sectors": [
+      {
+        "blocks": [
+        ],
+      },
+    ]
+  }
+}

--- a/src/commonTest/assets/mfc/mfc-incomplete1.json
+++ b/src/commonTest/assets/mfc/mfc-incomplete1.json
@@ -1,0 +1,15 @@
+{
+  "tagId": "12345679",
+  "scannedAt": {
+    "timeInMillis": 2,
+    "tz": "Etc/UTC"
+  },
+  "mifareClassic": {
+    "sectors": [
+      {
+        "blocks": [
+        ],
+      },
+    ]
+  }
+}

--- a/src/commonTest/kotlin/au/id/micolous/metrodroid/test/Utils.kt
+++ b/src/commonTest/kotlin/au/id/micolous/metrodroid/test/Utils.kt
@@ -1,5 +1,24 @@
+/*
+ * Utils.kt
+ *
+ * Copyright 2018-2019 Michael Farrell <micolous+git@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package au.id.micolous.metrodroid.test
 
+import au.id.micolous.metrodroid.ui.ListItem
 import kotlin.math.abs
 import kotlin.test.*
 
@@ -8,4 +27,18 @@ internal fun assertNear(expected: Double, actual: Double, tol: Double) {
         return
     // Fall to normal assertEquals so it shows everything
     assertEquals(expected, actual)
+}
+
+internal fun assertContainsListItem(
+        expected: ListItem, actual: Iterable<ListItem>, message: String? = null) {
+    assertNotNull(actual.firstOrNull{
+        it == expected
+    }, message)
+}
+
+internal fun assertNotContainsListItem(
+        expected: ListItem, actual: Iterable<ListItem>, message: String? = null) {
+    assertNull(actual.firstOrNull{
+        it == expected
+    }, message)
 }


### PR DESCRIPTION
* fix a crash in manufacturingInfo if sector 0 block 0 was not read
* separate NXP and Fudan manufacturer entries into static items for easier testing
* FormattedString: add .equals method
* ListItem: add .equals and .hashCode methods
* test.Utils: add assert(Not)?ContainsListItem
* add regression tests for Classic manufacturerInfo
* add regression test for incomplete Classic manufacturerInfo

```
Caused by: java.lang.IndexOutOfBoundsException: 
  at kotlin.collections.EmptyList.get (Collections.kt:34)
  at kotlin.collections.EmptyList.get (Collections.kt:22)
  at au.id.micolous.metrodroid.card.classic.ClassicCard.getManufacturingInfo (ClassicCard.kt:50)
  at au.id.micolous.metrodroid.card.Card.getManufacturingInfo (Card.kt:109)
  at au.id.micolous.metrodroid.activity.AdvancedCardInfoActivity.onCreate (AdvancedCardInfoActivity.kt:101)
  at android.app.Activity.performCreate (Activity.java:7136)
  at android.app.Activity.performCreate (Activity.java:7127)
  at android.app.Instrumentation.callActivityOnCreate (Instrumentation.java:1271)
  at android.app.ActivityThread.performLaunchActivity (ActivityThread.java:2924)
```
