### PR TITLE
Make stationTableReader code more reusable

### DIFF
--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/TransitName.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/TransitName.kt
@@ -1,0 +1,84 @@
+/*
+ * TransitName.kt
+ *
+ * Copyright (C) 2019 Google
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package au.id.micolous.metrodroid.transit
+
+import au.id.micolous.metrodroid.multi.FormattedString
+import au.id.micolous.metrodroid.util.Preferences
+
+class TransitName(
+    val englishFull: String?,
+    val englishShort: String?,
+    val localFull: String?,
+    val localShort: String?,
+    val localLanguagesList: List<String>,
+    val ttsHintLanguage: String
+) {
+    private fun useEnglishName(): Boolean {
+        val locale = Preferences.language
+        return !localLanguagesList.contains(locale)
+    }
+
+    fun selectBestName(isShort: Boolean): FormattedString? {
+        val english: String?
+        val hasEnglishFull = englishFull != null && !englishFull.isEmpty()
+        val hasEnglishShort = englishShort != null && !englishShort.isEmpty()
+
+        if (hasEnglishFull && !hasEnglishShort)
+            english = englishFull
+        else if (!hasEnglishFull && hasEnglishShort)
+            english = englishShort
+        else
+            english = if (isShort) englishShort else englishFull
+
+        val local: String?
+        val hasLocalFull = localFull != null && !localFull.isEmpty()
+        val hasLocalShort = localShort != null && !localShort.isEmpty()
+
+        if (hasLocalFull && !hasLocalShort)
+            local = localFull
+        else if (!hasLocalFull && hasLocalShort)
+            local = localShort
+        else
+            local = if (isShort) localShort else localFull
+
+        if (showBoth() && english != null && !english.isEmpty()
+                && local != null && !local.isEmpty()) {
+            if (english == local)
+                return FormattedString.language(local, ttsHintLanguage)
+            return if (useEnglishName()) FormattedString.english(english) + " (" + FormattedString.language(local, ttsHintLanguage) + ")" else FormattedString.language(local, ttsHintLanguage) + " (" + FormattedString.english(english) + ")"
+        }
+        if (useEnglishName() && english != null && !english.isEmpty()) {
+            return FormattedString.english(english)
+        }
+
+        return if (local != null && !local.isEmpty()) {
+            // Local preferred, or English not available
+            FormattedString.language(local, ttsHintLanguage)
+        } else if (english != null) {
+            // Local unavailable, use English
+            FormattedString.english(english)
+        } else
+            null
+    }
+
+    companion object {
+        private fun showBoth(): Boolean = Preferences.showBothLocalAndEnglish
+    }
+}

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/util/StationTableReader.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/util/StationTableReader.kt
@@ -1,23 +1,117 @@
 package au.id.micolous.metrodroid.util
 
 import au.id.micolous.metrodroid.multi.FormattedString
+import au.id.micolous.metrodroid.multi.Localizer
+import au.id.micolous.metrodroid.multi.R
 import au.id.micolous.metrodroid.transit.Station
+import au.id.micolous.metrodroid.transit.TransitName
 import au.id.micolous.metrodroid.transit.Trip
 
-expect class StationTableReader {
+expect internal fun StationTableReaderGetSTR(name: String): StationTableReader?
+
+data class ProtoStation(val operatorId: Int?, val name: TransitName, val latitude: Float, val longitude: Float, val lineIdList: List<Int>)
+
+interface StationTableReader {
+    val notice: String?
+
+    fun getOperatorDefaultMode(oper: Int): Trip.Mode?
+    
+    fun getOperatorName(oper: Int): TransitName?
+
+    fun getStationById(id: Int, humanReadableID: String): ProtoStation?
+
+    fun getLineName(id: Int): TransitName?
+
+    fun getLineMode(id: Int): Trip.Mode?
+
     companion object {
+        private fun fallbackName(id: Int): FormattedString =
+            Localizer.localizeFormatted(R.string.unknown_format, NumberUtils.intToHex(id))
+
+        private fun fallbackName(humanReadableId: String): FormattedString =
+            Localizer.localizeFormatted(R.string.unknown_format, humanReadableId)
+
+        private fun fromProto(humanReadableID: String, ps: ProtoStation,
+                              operatorName: TransitName?, pl: Map<Int, TransitName?>?): Station {
+            val hasLocation = ps.latitude != 0f && ps.longitude != 0f
+
+            var lines: MutableList<FormattedString>? = null
+            var lineIds: MutableList<String>? = null
+
+            if (pl != null) {
+                lines = ArrayList()
+                lineIds = ArrayList()
+                for ((first, second) in pl) {
+                    lines.addAll(listOfNotNull(second?.selectBestName(true)))
+                    lineIds.add(NumberUtils.intToHex(first))
+                }
+            }
+
+            return Station(
+                    humanReadableID,
+                    operatorName?.selectBestName(true),
+                    lines,
+                    ps.name.selectBestName(false),
+                    ps.name.selectBestName(true),
+                    if (hasLocation) ps.latitude else null,
+                    if (hasLocation) ps.longitude else null,
+                    false, lineIds.orEmpty())
+        }
+
         fun getStationNoFallback(reader: String?, id: Int,
-                                 humanReadableId: String = NumberUtils.intToHex(id)): Station?
+                                 humanReadableId: String = NumberUtils.intToHex(id)): Station? {
+            val str = StationTableReaderGetSTR(reader ?: return null) ?: return null
+            try {
+                val ps = str.getStationById(id, humanReadableId) ?: return null
+                val lines = mutableMapOf<Int, TransitName?>()
+                for (lineId in ps.lineIdList) {
+                    lines[lineId] = str.getLineName(lineId)
+                }
+                return fromProto(humanReadableId, ps,
+                     ps.operatorId?.let { str.getOperatorName(it) },
+                     lines)
+            } catch (e: Exception) {
+                return null
+            }
+        }
 
-        fun getStation(reader: String?, id: Int, humanReadableId: String = NumberUtils.intToHex(id)): Station
+        fun getStation(reader: String?, id: Int, humanReadableId: String = NumberUtils.intToHex(id)): Station {
+            val s = getStationNoFallback(reader, id, humanReadableId) ?: return Station.unknown(humanReadableId)
+            return s
+        }
 
-        fun getOperatorDefaultMode(reader: String?, id: Int): Trip.Mode
+        fun getOperatorDefaultMode(reader: String?, id: Int): Trip.Mode {
+            if (reader == null)
+                return Trip.Mode.OTHER
+            val str = StationTableReaderGetSTR(reader) ?: return Trip.Mode.OTHER
+            val m = str.getOperatorDefaultMode(id) ?: return Trip.Mode.OTHER
+            return m
+        }
 
-        fun getLineName(reader: String?, id: Int, humanReadableId: String = NumberUtils.intToHex(id)): FormattedString?
-        fun getLineMode(reader: String?, id: Int): Trip.Mode?
+        fun getLineName(reader: String?, id: Int, humanReadableId: String = NumberUtils.intToHex(id)): FormattedString? {
+            if (reader == null)
+                return fallbackName(humanReadableId)
+
+            val str = StationTableReaderGetSTR(reader) ?: return fallbackName(humanReadableId)
+            return str.getLineName (id)?.selectBestName(false) ?: return fallbackName(humanReadableId)
+        }
+
+        fun getLineMode(reader: String?, id: Int): Trip.Mode? {
+            val str = StationTableReaderGetSTR(reader ?: return null) ?: return null
+            return str.getLineMode(id)
+        }
 
         fun getOperatorName(reader: String?, id: Int, isShort: Boolean,
-                            humanReadableId: String = NumberUtils.intToHex(id)): FormattedString?
-        fun getNotice(reader: String?): String?
+                            humanReadableId: String = NumberUtils.intToHex(id)): FormattedString? {
+            val str = StationTableReaderGetSTR(reader ?: return fallbackName(humanReadableId)) ?: return fallbackName(humanReadableId)
+            return str.getOperatorName(id)?.selectBestName(isShort) ?: fallbackName(humanReadableId)
+        }
+
+        /**
+         * Gets a licensing notice that applies to a particular MdST file.
+         * @param reader Station database to read from.
+         * @return String containing license notice, or null if not available.
+         */
+        fun getNotice(reader: String?): String? = reader?.let { StationTableReaderGetSTR(it) }?.notice
     }
 }


### PR DESCRIPTION
    * Move post-processing logic to common main
    * Move proto/file reading integration to jvm-common
    * Encapsulate name-related concepts into new class TransitName
    * Make StationTableReader an interface for better separation

It's on top of valid2 branch