### PR TITLE
SubscriptionState: Replace description with descriptionRes

### DIFF
--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/Subscription.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/Subscription.kt
@@ -287,7 +287,7 @@ abstract class Subscription : Parcelable {
 
     open fun getAgencyName(isShort: Boolean): String? =  null
 
-    enum class SubscriptionState(val description: StringResource) {
+    enum class SubscriptionState(val descriptionRes: StringResource) {
         /** No state is known, display no UI for the state.  */
         UNKNOWN(R.string.unknown),
 

--- a/src/main/java/au/id/micolous/metrodroid/fragment/CardBalanceFragment.kt
+++ b/src/main/java/au/id/micolous/metrodroid/fragment/CardBalanceFragment.kt
@@ -163,7 +163,7 @@ class CardBalanceFragment : ListFragment() {
             if (subscription.subscriptionState === Subscription.SubscriptionState.UNKNOWN) {
                 usedView.visibility = View.GONE
             } else {
-                usedView.setText(subscription.subscriptionState.description)
+                usedView.setText(subscription.subscriptionState.descriptionRes)
                 usedView.visibility = View.VISIBLE
             }
 


### PR DESCRIPTION
This is to avoid conflict with swift's description (analog of toString()).