### PR TITLE
Fix localization situation with README.txt

### DIFF
--- a/src/main/java/au/id/micolous/metrodroid/multi/Localizer.kt
+++ b/src/main/java/au/id/micolous/metrodroid/multi/Localizer.kt
@@ -19,8 +19,13 @@
 
 package au.id.micolous.metrodroid.multi
 
+import android.content.res.Configuration
+import android.content.res.Resources
+import android.os.Build
+import androidx.annotation.RequiresApi
 import au.id.micolous.metrodroid.MetrodroidApplication
 import androidx.annotation.VisibleForTesting
+import java.util.*
 
 actual typealias StringResource = Int
 actual typealias DrawableResource = Int
@@ -56,4 +61,20 @@ actual object Localizer : LocalizerInterface {
             val appRes = MetrodroidApplication.instance.resources
             return appRes.getQuantityString(res, count, *v)
     }
+
+    private val englishResources: Resources by lazy {
+        val context = MetrodroidApplication.instance
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            var conf = context.resources.configuration
+            conf = Configuration(conf)
+            conf.setLocale(Locale.ENGLISH)
+            val localizedContext = context.createConfigurationContext(conf)
+            localizedContext.resources
+        } else {
+            // Whatever, keep it translated as fallback
+            context.resources
+        }
+    }
+
+    fun englishString(res: StringResource, vararg v: Any?): String = englishResources.getString(res, *v)
 }

--- a/src/main/java/au/id/micolous/metrodroid/util/ExportHelper.kt
+++ b/src/main/java/au/id/micolous/metrodroid/util/ExportHelper.kt
@@ -24,8 +24,11 @@ import android.content.ContentValues
 import android.content.Context
 import android.database.Cursor
 import android.net.Uri
+import android.os.Build
 
 import au.id.micolous.metrodroid.card.*
+import au.id.micolous.metrodroid.multi.Localizer
+import au.id.micolous.metrodroid.multi.R
 import au.id.micolous.metrodroid.serializers.*
 import au.id.micolous.metrodroid.time.MetroTimeZone
 import au.id.micolous.metrodroid.time.TimestampFull
@@ -92,36 +95,42 @@ object ExportHelper {
     fun makeFilename(card: Card): String = makeFilename(card.tagId.toHexString(),
                 card.scannedAt, "json", 0)
 
+    fun zipFileFromString(zo: ZipOutputStream, ts: TimestampFull, name: String, contents: String) {
+        ZipEntry(name).let { ze ->
+            ze.time = ts.timeInMillis
+            zo.putNextEntry(ze)
+        }
+        zo.write(ImmutableByteArray.fromUTF8(contents).dataCopy)
+        zo.closeEntry()
+    }
+
     fun exportCardsZip(os: OutputStream, context: Context) {
         val cursor = CardDBHelper.createCursor(context) ?: return
         val zo = ZipOutputStream(os)
         val used = HashSet<String>()
         val now = TimestampFull.now()
-        ZipEntry("README.txt").let { ze ->
-            ze.time = now.timeInMillis
-            zo.putNextEntry(ze)
-        }
-        val readme = "Exported by Metrodroid at ${now.isoDateTimeFormat()}\n" + Utils.deviceInfoString
-        zo.write(ImmutableByteArray.fromUTF8(readme).dataCopy)
-        zo.closeEntry()
+        zipFileFromString(zo, now,
+                Localizer.localizeString(R.string.readme_filename) + "." + Preferences.language + ".txt",
+                Localizer.localizeString(R.string.exported_at, now.isoDateTimeFormat()) + "\n" + Utils.deviceInfoString)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
+            zipFileFromString(zo, now,
+                    Localizer.englishString(R.string.readme_filename) + ".txt",
+                    Localizer.englishString(R.string.exported_at, now.format()) + "\n" + Utils.deviceInfoStringEnglish)
 
         while (cursor.moveToNext()) {
             val content = cursor.getString(cursor.getColumnIndex(CardsTableColumns.DATA)).trim { it <= ' ' }
             val scannedAt = cursor.getLong(cursor.getColumnIndex(CardsTableColumns.SCANNED_AT))
             val tagId = cursor.getString(cursor.getColumnIndex(CardsTableColumns.TAG_SERIAL))
+            val scannedAtTs = TimestampFull(scannedAt, MetroTimeZone.LOCAL)
+            val ext = if (content[0] == '<') "xml" else "json"
             var name: String
             var gen = 0
             do
-                name = makeFilename(tagId, TimestampFull(scannedAt,
-                        MetroTimeZone.LOCAL),
-                        if (content[0] == '<') "xml" else "json", gen++)
+                name = makeFilename(tagId, scannedAtTs, ext, gen++)
             while (used.contains(name))
             used.add(name)
-            val ze = ZipEntry(name)
-            ze.time = scannedAt
-            zo.putNextEntry(ze)
-            zo.write(content.toByteArray(Charsets.UTF_8))
-            zo.closeEntry()
+            zipFileFromString(zo, scannedAtTs, name, content)
         }
         zo.close()
     }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1910,4 +1910,6 @@
     <string name="raw_header">Raw fields</string>
     <string name="hardware">Hardware</string>
     <string name="android_nfc_settings">Android NFC settings</string>
+    <string name="exported_at">Exported by Metrodroid at %s</string>
+    <string name="readme_filename">README</string>
 </resources>


### PR DESCRIPTION
In README.txt first string is always in English and the rest is in local
language.

Instead, create 2 readme's: one in English and one in local language.