### PR TITLE
Avoid unsupported plurals without explicit numeral

### DIFF
--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/Subscription.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/Subscription.kt
@@ -271,15 +271,10 @@ abstract class Subscription : Parcelable {
 
             val zones = zones
             if (zones != null && zones.isNotEmpty()) {
-                val zones_list = StringBuilder()
-                for (z in zones) {
-                    if (zones_list.isNotEmpty())
-                        zones_list.append(", ")
-                    zones_list.append(z.toString())
-                }
+                val zones_list = zones.joinToString { it.toString() }
 
                 items.add(ListItem(Localizer.localizePlural(R.plurals.travel_zones,
-                        zones.size), zones_list.toString()))
+                        zones.size), zones_list))
             }
 
             return items.ifEmpty { null }

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/Subscription.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/Subscription.kt
@@ -274,7 +274,7 @@ abstract class Subscription : Parcelable {
                 val zones_list = zones.joinToString { it.toString() }
 
                 items.add(ListItem(Localizer.localizePlural(R.plurals.travel_zones,
-                        zones.size), zones_list))
+                        zones.size, zones.size), zones_list))
             }
 
             return items.ifEmpty { null }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -522,6 +522,7 @@
         <item quantity="one">%d trip remaining out of %d</item>
         <item quantity="other">%d trips remaining out of %d</item>
     </plurals>
+    <!-- Translarors: This a ticket name. Feel free to replace with "Ticket for %d ride(s). -->
     <plurals name="troika_rides">
         <item quantity="one">Single-ride</item>
         <item quantity="other">%d-ride</item>
@@ -1639,6 +1640,8 @@
     <!-- Translators: Exponent for the primary currency. This is 2 for the Euro and most dollars,
     0 for yen.  -->
     <string name="emv_application_currency_exponent">Application currency exponent</string>
+    <!-- Translators: This is used as a title for a table row, so feel free to replace with
+         "Number of remaining pin attempts" for all plurals. -->
     <plurals name="emv_pin_attempts_remaining">
         <item quantity="one">PIN attempt remaining</item>
         <item quantity="other">PIN attempts remaining</item>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1309,8 +1309,8 @@
         <item quantity="other">%d days remaining</item>
     </plurals>
     <plurals name="travel_zones">
-        <item quantity="one">Travel zone</item>
-        <item quantity="other">Travel zones</item>
+        <item quantity="one">%d travel zone</item>
+        <item quantity="other">%d travel zones</item>
     </plurals>
 
     <string name="en1545_network_id">Network ID</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -510,8 +510,8 @@
 
     <!-- Type: Linear record, Records: 4 (6 maximum), Record size: 40 -->
     <plurals name="desfire_record_format">
-        <item quantity="one">Type: %1$s, record: %2$s (%3$s maximum), record size: %4$s</item>
-        <item quantity="other">Type: %1$s, records: %2$s (%3$s maximum), record size: %4$s</item>
+        <item quantity="one">Type: %1$s, %2$d record (%3$d maximum), record size: %4$d</item>
+        <item quantity="other">Type: %1$s, %2$d records (%3$d maximum), record size: %4$d</item>
     </plurals>
 
     <plurals name="trips_remaining">


### PR DESCRIPTION
Some languages e.g. Russian have different handling for plurals when
the numeral is present and when it's not. E.g. in Russian
For 1: "1 Zona" or simply "Zona"
For 21: "21 Zona" but "Zony" if number is not explicitly specified
As you can see in the presence of numeral both 1 and 21 use the same form but
not in its absence.
Unfortunately Android uses form "one" for both 1 and 21. So it supports only
strings with explicit numeral.
So add the explicit numeral or provide an alternative