### PR TITLE
ultralight, nfcv: drop collapsing values

### DIFF
--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/nfcv/NFCVCard.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/nfcv/NFCVCard.kt
@@ -51,12 +51,12 @@ data class NFCVCard constructor(
             val pageIndexString = idx.hexString
 
             if (sector.isUnauthorized) {
-                ListItemRecursive.collapsedValue(Localizer.localizeString(
+                ListItem(Localizer.localizeFormatted(
                         R.string.unauthorized_page_title_format, pageIndexString),
-                        null, null)
+                        null)
             } else {
-                ListItemRecursive.collapsedValue(Localizer.localizeString(
-                        R.string.page_title_format, pageIndexString), null, sector.data.toHexDump())
+                ListItem(Localizer.localizeFormatted(
+                        R.string.page_title_format, pageIndexString), sector.data.toHexDump())
             }
         }
 

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/ultralight/UltralightCard.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/ultralight/UltralightCard.kt
@@ -55,12 +55,12 @@ data class UltralightCard constructor(
             val pageIndexString = idx.hexString
 
             if (sector.isUnauthorized) {
-                ListItemRecursive.collapsedValue(Localizer.localizeString(
+                ListItem(Localizer.localizeFormatted(
                         R.string.unauthorized_page_title_format, pageIndexString),
-                        null, null)
+                        null)
             } else {
-                ListItemRecursive.collapsedValue(Localizer.localizeString(
-                        R.string.page_title_format, pageIndexString), null, sector.data.toHexDump())
+                ListItem(Localizer.localizeFormatted(
+                        R.string.page_title_format, pageIndexString), sector.data.toHexDump())
             }
         }
 


### PR DESCRIPTION
Collapsing is useful when a single entry is long enough but ultralight/NFCV
pages are only 4 bytes. Collapsing them only makes it more difficult to see
around