### PR TITLE
subscription_item: Allow subscription name to span several lines

### DIFF
--- a/src/main/res/layout/subscription_item.xml
+++ b/src/main/res/layout/subscription_item.xml
@@ -93,7 +93,7 @@
             android:layout_width="0dp"
             android:layout_height="76dp"
             android:gravity="center"
-            android:maxLines="1"
+            android:maxLines="5"
             android:paddingBottom="4dp"
             android:paddingTop="4dp"
             android:singleLine="false"


### PR DESCRIPTION
Some subscription name end up too long for a single line, allow it to
overflow