### PR TITLE
XmlOrJsonFormat: Simplify ZIP handling

### DIFF
--- a/src/androidTest/java/au/id/micolous/metrodroid/test/ExportHelperTest.kt
+++ b/src/androidTest/java/au/id/micolous/metrodroid/test/ExportHelperTest.kt
@@ -41,12 +41,13 @@ class ExportHelperTest : BaseInstrumentedTest() {
         val readmeFilename = "README." + Preferences.language + ".txt"
 
         var hasReadme = false
-        XmlOrJsonCardFormat.ZipIterator(zis).forEach {
-            if (readmeFilename == it.first.name) {
+        while(true) {
+            val ze = zis.nextEntry ?: break
+            if (readmeFilename == ze.name) {
                 hasReadme = true
 
                 // Read the file and see if there's a version code
-                val b = it.second.readBytes()
+                val b = zis.readBytes()
                 val content = b.toString(Charsets.UTF_8)
                 assertTrue(check(content), "Content check failed, got: \"$content\"")
             }

--- a/src/jvmCommonMain/kotlin/au/id/micolous/metrodroid/serializers/XmlOrJsonFormat.kt
+++ b/src/jvmCommonMain/kotlin/au/id/micolous/metrodroid/serializers/XmlOrJsonFormat.kt
@@ -35,46 +35,24 @@ class XmlOrJsonCardFormat : CardImporter {
         when (peek(pb)) {
             '<' -> return iterateXmlCards(pb) { readCard(it) }
             '[', '{' -> return listOf(jsonKotlinFormat.readCard(pb.bufferedReader().readText())).iterator()
-            'P' -> return readZip(pb)
+            'P' -> return readZip(pb).iterator()
             else -> return null
         }
     }
 
-    class ZipIterator (private val zi: ZipInputStream)
-        : Iterator<Pair<ZipEntry, InputStream>> {
-        override fun next(): Pair<ZipEntry, InputStream> {
-            if (!advanced)
-                ze = zi.nextEntry
-            advanced = false
-            return Pair(ze!!, zi)
-        }
-
-        private var ze: ZipEntry? = null
-        private var end = false
-        private var advanced = false
-        override fun hasNext(): Boolean {
-            if (end)
-                return false
-            if (!advanced)
-                ze = zi.nextEntry
-            advanced = true
-            if (ze == null)
-                end = true
-            return !end
-        }
-    }
-
-    private fun readZip(stream: InputStream): Iterator<Card>? {
-        return IteratorTransformerNotNull(ZipIterator(ZipInputStream(stream))) {
-            (ze, zi) ->
+    private fun readZip(stream: InputStream): List<Card> {
+        val zi = ZipInputStream(stream)
+        val m = mutableListOf<Card>()
+        while (true) {
+            val ze = zi.nextEntry ?: break
             Log.d("Importer", "Importing ${ze.name}")
             when {
-                ze.name.endsWith(".json") -> jsonKotlinFormat.readCard(zi.bufferedReader().readText())
-                ze.name.endsWith(".xml") -> readCardXML(zi)
-                ze.name.endsWith(".mfc") -> mfcFormat.readCard(zi)
-                else -> null
+                ze.name.endsWith(".json") -> m += jsonKotlinFormat.readCard(zi.bufferedReader().readText())
+                ze.name.endsWith(".xml") -> m += readCardXML(zi)
+                ze.name.endsWith(".mfc") -> m += mfcFormat.readCard(zi)
             }
         }
+        return m
     }
 
     override fun readCard(stream: InputStream): Card {


### PR DESCRIPTION
ZipIterator is clumsy, large and difficult to read. Instead replace it
by way simpler direct iteration logic