### PR TITLE
fix #885 add label for french navigo metro-train-rer tickets

### DIFF
--- a/src/androidMain/res/values-fr/strings.xml
+++ b/src/androidMain/res/values-fr/strings.xml
@@ -882,6 +882,7 @@
     <string name="navigo_forfait_imagineR_etudiant">Abonnement ImagineR Étudiant</string>
     <string name="navigo_forfait_liberte">Abonnement Navigo Libetré+</string>
     <string name="navigo_ticket_tplus">Ticket T+</string>
+    <string name="navigo_metro_train_rer">Metro-Train-RER ticket</string>
     <string name="oura_billet_tarif_normal">Billet à tarif normal</string>
     <string name="gironde_line">Ligne %d</string>
     <string name="ilevia_trajet_unitaire">Ilévia trajet unitaire</string>

--- a/src/androidMain/res/values/strings.xml
+++ b/src/androidMain/res/values/strings.xml
@@ -2576,6 +2576,8 @@
     <string name="navigo_forfait_liberte">Navigo Liberté+ subscription</string>
     <!-- Translators: a single ride ticket. French "Ticket T+" -->
     <string name="navigo_ticket_tplus">T+ ticket</string>
+    <!-- Translators: a single ride ticket. French "Metro-Train-RER" -->
+    <string name="navigo_metro_train_rer">Metro-Train-RER ticket</string>
     <!-- Translators: French "Billet Tarif Normal" -->
     <string name="oura_billet_tarif_normal">Normal-price ticket</string>
     <!-- Translators: French "Ligne %d" -->

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/intercode/IntercodeLookupNavigo.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/intercode/IntercodeLookupNavigo.kt
@@ -79,6 +79,7 @@ internal object IntercodeLookupNavigo : IntercodeLookupSTR(NAVIGO_STR) {
             16384 to R.string.navigo_forfait_mois_75,
             16385 to R.string.navigo_forfait_semaine_75,
             20480 to R.string.navigo_ticket_tplus,
+            20488 to R.string.navigo_metro_train_rer,
             32771 to R.string.navigo_forfait_solidarite_gratuite,
     )
 


### PR DESCRIPTION
this fixes #885 by adding a label to one more navigo journey ticket type.