### PR TITLE
Remove dependency info from APKs and AABs.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -662,6 +662,14 @@ android {
         }
     }
 
+    dependenciesInfo {
+        // This metadata is added to the APK in an encrypted form, which isn't useful to anyone but
+        // Google, and is a source of non-determinism.
+        // https://izzyondroid.org/about/security/ApkScans/#signingblock-checks
+        includeInApk = false
+        includeInBundle = false
+    }
+
     preBuild.dependsOn copyThirdPartyNotices
 
     sourceSets {


### PR DESCRIPTION
Feedback from https://github.com/metrodroid/metrodroid/issues/880#issuecomment-3546386528

Dependency metadata added to the APK/AABs as an encrypted blob, which is a potential source of non-determinism that is difficult to debug, and is useless to anyone but Google.
