### PR TITLE
WIP: use the VAS application to detect Apple Pay and apply HCE work-arounds

### DIFF
--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/iso7816/ISO7816Card.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/iso7816/ISO7816Card.kt
@@ -29,6 +29,7 @@ import au.id.micolous.metrodroid.card.CardProtocol
 import au.id.micolous.metrodroid.card.CardTransceiver
 import au.id.micolous.metrodroid.card.TagReaderFeedbackInterface
 import au.id.micolous.metrodroid.card.androidhce.AndroidHceApplication
+import au.id.micolous.metrodroid.card.vas.VasApplication
 import au.id.micolous.metrodroid.card.calypso.CalypsoApplication
 import au.id.micolous.metrodroid.card.cepas.CEPASApplication
 import au.id.micolous.metrodroid.card.china.ChinaCard
@@ -54,11 +55,16 @@ import kotlinx.serialization.Serializable
 
 val factories = listOf(
     AndroidHceApplication.FACTORY,
+    VasApplication.FACTORY,
     CalypsoApplication.FACTORY,
     KROCAPConfigDFApplication.FACTORY,
     KSX6924Application.FACTORY,
     ChinaCard.FACTORY,
     EmvFactory())
+
+val hceApplications = AndroidHceApplication.FACTORY.applicationNames.toSet().union(
+    VasApplication.FACTORY.applicationNames
+)
 
 object ISO7816AppSerializer : MultiTypeSerializer<ISO7816Application>() {
     private val klasses =

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/vas/VasApplication.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/vas/VasApplication.kt
@@ -1,0 +1,67 @@
+/*
+ * VasApplication.kt
+ *
+ * Copyright 2025 Michael Farrell <micolous+git@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package au.id.micolous.metrodroid.card.vas
+
+import au.id.micolous.metrodroid.card.TagReaderFeedbackInterface
+import au.id.micolous.metrodroid.card.iso7816.*
+import au.id.micolous.metrodroid.util.ImmutableByteArray
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+
+/**
+ * VAS application.
+ *
+ * https://github.com/kormax/apple-vas
+ *
+ * This implementation is incomplete, but we can use this to detect Apple and Google Pay, and read
+ * EMV more reliably.
+ */
+@Serializable
+data class VasApplication(
+    override val generic: ISO7816ApplicationCapsule) : ISO7816Application() {
+
+    override val type: String
+        get() = TYPE
+
+    companion object {
+        private val FILENAMES = listOf(
+            ImmutableByteArray.fromHex("4F53452E5641532E3031")
+        )
+
+        private const val TYPE = "applevas"
+
+        val FACTORY: ISO7816ApplicationFactory = object : ISO7816ApplicationFactory {
+            override val typeMap: Map<String, KSerializer<out ISO7816Application>>
+                get() = mapOf(TYPE to serializer() )
+            override val applicationNames: Collection<ImmutableByteArray>
+                get() = FILENAMES
+
+            override fun dumpTag(
+                protocol: ISO7816Protocol,
+                capsule: ISO7816ApplicationMutableCapsule,
+                feedbackInterface: TagReaderFeedbackInterface,
+                presentAids: List<ImmutableByteArray?>
+            ): List<ISO7816Application> {
+                // TODO: read data files
+                return listOf<ISO7816Application>(VasApplication(capsule.freeze()))
+            }
+        }
+    }
+}
+

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/vas/VasApplication.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/vas/VasApplication.kt
@@ -44,7 +44,7 @@ data class VasApplication(
             ImmutableByteArray.fromHex("4F53452E5641532E3031")
         )
 
-        private const val TYPE = "applevas"
+        private const val TYPE = "vas"
 
         val FACTORY: ISO7816ApplicationFactory = object : ISO7816ApplicationFactory {
             override val typeMap: Map<String, KSerializer<out ISO7816Application>>


### PR DESCRIPTION
***This is a work in progress, and needs some more testing.***

Both Apple Pay and Google Pay EMV implementations expose much less data than physical cards, so return a lot of errors when Metrodroid tries to scan them. They also enforce an error budget, so if an initiator requests makes too many requests that error, they will stop accepting _any_ commands.

[Metrodroid currently detects Android-based HCE](https://github.com/metrodroid/metrodroid/blob/04a603ba639f7a270b7bdbf24158c7d601087c29/src/commonMain/kotlin/au/id/micolous/metrodroid/card/androidhce/AndroidHceApplication.kt) using `A000000476416E64726F6964484345`... which doesn't work for Apple devices.

Both Apple Pay and Google Pay expose [a VAS application](https://github.com/kormax/apple-vas) (`OSE.VAS.01` / `4F53452E5641532E3031`), which can be used to expose merchant-specific vouchers during an EMV transaction.

This PR uses the presence of VAS to apply the Google Pay HCE work-arounds to Apple Pay as well. It doesn't try to probe this application at all... and this seems to work even _without_ [ECP](https://github.com/kormax/apple-enhanced-contactless-polling).

This PR doesn't attempt HCE vendor identification, even though the data is available.

## Compatibility

This introduces a new ISO 7816 application type, `vas`.

Any card scans which include this application won't be readable by versions of Metrodroid without this PR, and you'll need to patch it out of the JSON dumps (where `iso7816.applications[*][0] == "vas"`).

## Testing

I've tested this successfully with Metrodroid on Android and JVM with Apple Pay.

The JVM version requires an NFC initiator that supports extended APDUs and time extension requests, due to some long responses. For example, this *doesn't* work properly with ACS ACR122U.

## Open issues

* I've only tested this with Apple Pay. It needs testing with Google Pay, etc.

* I haven't tested this using Metrodroid on iOS. That doesn't support EMV cards anyway (due to dynamic application selection).

* I'm not able to test this with virtual transit cards loaded into Apple Pay. These cause Apple Pay to respond to more application IDs and in strange ways (especially with Chinese cards), so may appear as some sort of hybrid.

  This would also be an issue with virtual transit cards loaded into other HCE wallets anyway... so I'm not sure how much to worry about this. :)
