### PR TITLE
Drop allowUniversalAccessFromFileURLs in TripMapFragment

### DIFF
--- a/src/androidMain/kotlin/au/id/micolous/metrodroid/fragment/TripMapFragment.kt
+++ b/src/androidMain/kotlin/au/id/micolous/metrodroid/fragment/TripMapFragment.kt
@@ -64,7 +64,13 @@ class TripMapFragment: Fragment() {
 
         val settings = webView.settings
         settings.javaScriptEnabled = true
-        settings.allowUniversalAccessFromFileURLs = true
+        // The map page (file:///android_asset/map.html) only uses Leaflet
+        // to render tile images via L.tileLayer, which fetches tiles with
+        // <img> tags rather than XHR. <img> loads from a file:// page to
+        // any origin are not gated by allowUniversalAccessFromFileURLs,
+        // so the flag is not needed for the existing map flow, and
+        // leaving it on lets the TripMapShim JS bridge be reached from a
+        // same-origin file:// page that exfiltrates to any host.
 
         settings.userAgentString = "${settings.userAgentString} metrodroid/${BuildConfig.VERSION_NAME}"
 


### PR DESCRIPTION
Closes #901.

`TripMapFragment` loads `file:///android_asset/map.html` into a WebView that has `setJavaScriptEnabled(true)` and attaches the `TripMapShim` JS bridge:

```kotlin
settings.javaScriptEnabled = true
settings.allowUniversalAccessFromFileURLs = true
...
webView.addJavascriptInterface(shim, "TripMapShim")
webView.loadUrl("file:///android_asset/map.html")
```

The map page itself only loads Leaflet (`assets/third_party/leaflet/leaflet.js`) and `assets/js/map.js`, which uses `L.tileLayer(tileUrl, ...)` to render tiles. Leaflet's tile layer fetches tiles via `<img>` tags, not XHR. Image loads from a `file://` page to any origin are not gated by `allowUniversalAccessFromFileURLs`, so the existing map flow does not depend on this flag.

Leaving the flag on lets a `file://` page reach the `TripMapShim` bridge and XHR any origin (CWE-200, the universal-XSS pattern). This PR drops it.

### Scope

One line removed, replaced with a short comment explaining why the flag is not needed. No other WebView setting touched, no change to map rendering or to the `TripMapShim` bridge.