### PR TITLE
Implementing UIKit scene lifecycle to avoid launch failures on iOS 27

### DIFF
--- a/native/metrodroid/metrodroid/AppDelegate.swift
+++ b/native/metrodroid/metrodroid/AppDelegate.swift
@@ -30,34 +30,49 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         return true
     }
-    
+
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-        HistoryViewController.importFile(navigationController: window?.rootViewController as! UINavigationController, from: url)
+        guard let navigationController = rootNavigationController() else {
+            return false
+        }
+
+        HistoryViewController.importFile(navigationController: navigationController, from: url)
         return true
     }
 
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    private func rootNavigationController() -> UINavigationController? {
+        if #available(iOS 13.0, *) {
+            return UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .flatMap { $0.windows }
+                .first { $0.isKeyWindow }?
+                .rootViewController as? UINavigationController
+        }
+
+        return window?.rootViewController as? UINavigationController
+    }
+
     func applicationWillResignActive(_ application: UIApplication) {
-        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits and the application begins the transition to the background state.
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {
-        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+        // Release shared resources, save user data, invalidate timers, and store enough application state information to restore the application to its current state if it is terminated later.
     }
 
     func applicationWillEnterForeground(_ application: UIApplication) {
-        // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
+        // Called as part of the transition from the background to the active state.
     }
 
     func applicationDidBecomeActive(_ application: UIApplication) {
-        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+        // Restart tasks that were paused while the application was inactive.
     }
 
     func applicationWillTerminate(_ application: UIApplication) {
-        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+        // Called when the application is about to terminate.
     }
-
-
 }
-

--- a/native/metrodroid/metrodroid/SceneDelegate.swift
+++ b/native/metrodroid/metrodroid/SceneDelegate.swift
@@ -1,0 +1,49 @@
+//
+//  SceneDelegate.swift
+//
+// Copyright 2026 Google
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        guard connectionOptions.urlContexts.isEmpty == false else {
+            return
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            self?.importFirstURL(from: connectionOptions.urlContexts)
+        }
+    }
+
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        importFirstURL(from: URLContexts)
+    }
+
+    private func importFirstURL(from urlContexts: Set<UIOpenURLContext>) {
+        guard let url = urlContexts.first?.url,
+              let navigationController = window?.rootViewController as? UINavigationController else {
+            return
+        }
+
+        HistoryViewController.importFile(navigationController: navigationController, from: url)
+    }
+}

--- a/native/metrodroid/metrodroid/SceneDelegate.swift
+++ b/native/metrodroid/metrodroid/SceneDelegate.swift
@@ -1,7 +1,6 @@
 //
 //  SceneDelegate.swift
 //
-// Copyright 2026 Google
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
iOS 27 SDK mandates UIKit scene lifecycle, otherwise the app won't launch at all.

`failure in void _UIApplicationEvaluateRuntimeIssueForNoSceneLifecycleAdoption(void)_block_invoke (UIApplication_RuntimeIssues.m:106) : Application failed to launch: UIScene life cycle is required for apps built with this SDK. See "Transitioning to the UIKit scene-based life cycle" in the UIKit documentation for more information on migration.`

I've fixed this with some effort and so far it worked ok (Xcode 27 beta 2 on macOS 26.5, iPhone on iOS 27 beta 3) for reading and interacting with a Lisboa Navegante (Viva) card.